### PR TITLE
Cut subgraph storage for sgd48 reindex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 build
 .DS_Store
 dao-contracts
+tests/.bin
+tests/.latest.json

--- a/README.md
+++ b/README.md
@@ -1,40 +1,48 @@
-This subgraph indexes different data from VeChain's VeBetterDAO:
+This subgraph indexes VeBetterDAO activity with a storage-cut profile tuned for fresh reindexing.
 
-1. B3TR, VOT3 and veB3TR Tokens with OpenZeppelin's ERC20 Template
-2. Government contracts based on OpenZeppelin's voting, timelock, and governor templates
-3. Rounds, with information about:
-    - Allocation Votes
-    - Reward Claims
-4. Apps including their IPFS Metadata
-5. Proposals including their IPFS Metadata
-6. veDelegate.vet Token Bound Accounts (NFTs + Account Abstraction Wallets)
-7. Timeseries of Allocation votes by app and round
-8. Sustainability Proofs including Timeseries of impacts
-9. Passport scoring and linking
+It keeps:
 
-The data provided offers information about:
+1. ERC20 balances, approvals, and total supply snapshots for `B3TR`, `VOT3`, and `veB3TR`
+2. Governance rounds, allocation aggregates, reward claim aggregates, and proposal aggregates
+3. App metadata, proposal metadata, and veDelegate account state
+4. Passport delegation/linking state plus compact passport score counters
+5. Reward-pool summaries plus one raw reward transfer feed
 
-1. Generic Token Activity
-2. Round Statistics
-3. App Allocation Voting Behavior
-4. Insight into a subset of veDelegate.vet behavior
-5. Proposal Metadata
-6. Insight into Sustainability Proofs
-7. Balance and activity of users (single or all tokens aggregated)
-8. Passports (delegations, entities, scores, white/blacklists)
+It does not keep:
 
-The subgraph is deployed publicly on: https://graph.vet/subgraphs/name/vebetter/dao  
-It powers the statistic pages on https://veDelegate.vet/stats 
+1. Raw allocation vote entities
+2. Raw governance vote receipt entities
+3. Raw sustainability proof entities
+4. Raw `PassportScore` entities
+5. Raw `DelegateVotesChanged` entities
+6. Raw reward-pool deposit, withdraw, and distribution entities as separate tables
 
-To deploy locally, run a graph-node connected to VeChain as explained in [vechain-energy/graph-node](https://github.com/vechain-energy/graph-node) and deploy it with:
+## Storage Rules
 
+- `RewardPoolTransfer` is the only raw reward-pool event entity.
+- `RewardPoolTransfer.kind` is `DEPOSIT`, `WITHDRAW`, or `DISTRIBUTION`.
+- `RewardPoolTransfer.reason` is only set for team withdrawals.
+- Hot synthetic IDs now use `Bytes` for compact storage where human-readable IDs are not needed.
+- Zero-value `ERC20Balance`, `VBDBalance`, and `ERC20Approval` rows are removed from store. Missing row means zero.
+- `indexerHints.prune: auto` is enabled in [`subgraph.yaml`](subgraph.yaml).
 
-```shell
+## Query Notes
+
+- Prefer natural-field filters over direct `id` lookups for hashed summary tables.
+- Use `rewardPoolTransfers(where: { app: "...", round: "1", kind: DISTRIBUTION })` for reward history.
+- Use `appRoundSummaries(where: { app: "...", round: "1" })` for app round summaries.
+- Use `accountSustainabilities(where: { account: "...", app: "..." })` for account reward totals.
+- Use `accountRoundSustainabilities(where: { account: "...", app: "...", round: "1" })` for per-round reward totals.
+- Use `erc20Balances(where: { contract: "...", account: "..." })` and `erc20Approvals(where: { contract: "...", owner: "...", spender: "..." })` for live token state.
+
+Full API notes live in [`docs/storage-optimized-subgraph.md`](docs/storage-optimized-subgraph.md).
+
+## Local Work
+
+```sh
 npx graph codegen subgraph.yaml
-npx graph create vebetter/dao --node http://127.0.0.1:8020
-npx graph deploy vebetter/dao --ipfs http://127.0.0.1:5001 --node http://127.0.0.1:8020 subgraph.yaml --version-label 1
+npx graph test
+npx graph build subgraph.yaml
 ```
 
---
-
-Contributions to improve the indexing or widen the scope are very welcome!
+For local deploys, run a `graph-node` connected to VeChain and then deploy with your normal `graph create` and `graph deploy` commands.

--- a/docs/storage-optimized-subgraph.md
+++ b/docs/storage-optimized-subgraph.md
@@ -1,0 +1,179 @@
+# Storage-Optimized Subgraph
+
+## Goal
+
+This profile is for a fresh reindex.
+
+Target:
+
+- keep current dashboard behavior
+- cut raw event storage
+- cut index size on hot mutable tables
+- keep `indexerHints.prune: auto`
+
+The Graph still recommends pruning plus `Bytes` IDs for non-human keys and immutable event entities where possible:
+
+- [Pruning best practices](https://thegraph.com/docs/en/subgraphs/best-practices/pruning/)
+- [Bytes IDs and immutable entities](https://thegraph.com/docs/en/subgraphs/cookbook/immutable-entities-bytes-as-ids/)
+- [Schema guidance](https://thegraph.com/docs/en/subgraphs/developing/creating/ql-schema/)
+
+## Reward Pool Shape
+
+Raw reward history is now one table only:
+
+- `RewardPoolTransfer`
+
+New fields:
+
+- `kind: RewardPoolTransferKind!`
+- `reason: String`
+
+Removed raw reward entities:
+
+- `RewardPoolDeposit`
+- `RewardPoolWithdraw`
+- `RewardPoolDistribution`
+
+Removed duplicate link fields from `RewardPoolTransfer`:
+
+- `deposit`
+- `withdraw`
+- `distribution`
+
+Use queries like:
+
+```graphql
+query RewardFeed($app: Bytes!, $round: String!) {
+  rewardPoolTransfers(
+    first: 100
+    orderBy: timestamp
+    orderDirection: desc
+    where: { app: $app, round: $round }
+  ) {
+    id
+    timestamp
+    kind
+    reason
+    amountExact
+    from {
+      id
+    }
+    to {
+      id
+    }
+  }
+}
+```
+
+## Removed Raw Histories
+
+These raw entities are gone:
+
+- `PassportScore`
+- `DelegateVotesChanged`
+
+These summary surfaces stay:
+
+- `RoundStatistic.totalActionScores`
+- `AppRoundSummary.passportScore`
+- `AccountRoundSustainability.passportScore`
+- `VoteWeight`
+- `VoteDelegation`
+
+Compact passport counters now live on `Account`:
+
+- `passportActionCount`
+- `passportScoreTotal`
+- `lastActivityTimestamp`
+
+## Byte IDs
+
+The following hot synthetic IDs now use `Bytes`:
+
+- `Transaction`
+- `RewardPoolTransfer`
+- `RewardClaimed`
+- `ERC20Balance`
+- `VBDBalance`
+- `ERC20Approval`
+- `AccountSustainability`
+- `AccountRoundSustainability`
+- `AppRoundSummary`
+- `SustainabilityStats`
+
+Event entities use `event.transaction.hash.concatI32(event.logIndex.toI32())`.
+
+Summary tables use fixed byte composite IDs or hashed byte composite IDs from [`src/ids.ts`](../src/ids.ts).
+
+Because these IDs are not human-friendly, prefer filter queries over direct `id` lookups:
+
+```graphql
+query AppRoundSummary($app: Bytes!, $round: String!) {
+  appRoundSummaries(first: 1, where: { app: $app, round: $round }) {
+    id
+    activeUserCount
+    poolBalanceExact
+    poolDepositsExact
+    poolWithdrawalsExact
+    poolDistributionsExact
+    passportScore
+    sustainabilityStats {
+      rewards
+      newUserCount
+      actionCount
+    }
+  }
+}
+```
+
+```graphql
+query AccountRewardSummary($account: Bytes!, $app: Bytes!, $round: String!) {
+  accountSustainabilities(first: 1, where: { account: $account, app: $app }) {
+    receivedRewards
+  }
+
+  accountRoundSustainabilities(
+    first: 1
+    where: { account: $account, app: $app, round: $round }
+  ) {
+    receivedRewards
+    passportScore
+  }
+}
+```
+
+## Zero-Row Semantics
+
+Zero-value snapshots are removed from store for:
+
+- `ERC20Balance`
+- `VBDBalance`
+- `ERC20Approval`
+
+Meaning:
+
+- missing balance row = zero balance
+- missing approval row = zero allowance
+
+Use filters instead of assuming the row exists:
+
+```graphql
+query TokenState($contract: Bytes!, $account: Bytes!, $spender: Bytes!) {
+  erc20Balances(first: 1, where: { contract: $contract, account: $account }) {
+    valueExact
+  }
+
+  erc20Approvals(
+    first: 1
+    where: { contract: $contract, owner: $account, spender: $spender }
+  ) {
+    valueExact
+  }
+}
+```
+
+## Reindex Notes
+
+- This schema is not graft-compatible with older raw-history deployments.
+- Rebuild as a fresh namespace, such as `sgd48`.
+- After reindex, validate namespace size, removed tables, and zero-row counts for `erc20_balance`, `vbd_balance`, and `erc20_approval`.

--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -763,14 +763,6 @@ export class App extends Entity {
     this.set("poolDepositsExact", Value.fromBigInt(value));
   }
 
-  get poolDepositEvent(): RewardPoolDepositLoader {
-    return new RewardPoolDepositLoader(
-      "App",
-      this.get("id")!.toBytes().toHexString(),
-      "poolDepositEvent",
-    );
-  }
-
   get poolWithdrawals(): BigDecimal {
     let value = this.get("poolWithdrawals");
     if (!value || value.kind == ValueKind.NULL) {
@@ -795,14 +787,6 @@ export class App extends Entity {
 
   set poolWithdrawalsExact(value: BigInt) {
     this.set("poolWithdrawalsExact", Value.fromBigInt(value));
-  }
-
-  get poolWithdrawEvent(): RewardPoolWithdrawLoader {
-    return new RewardPoolWithdrawLoader(
-      "App",
-      this.get("id")!.toBytes().toHexString(),
-      "poolWithdrawEvent",
-    );
   }
 
   get poolDistributions(): BigDecimal {
@@ -831,19 +815,11 @@ export class App extends Entity {
     this.set("poolDistributionsExact", Value.fromBigInt(value));
   }
 
-  get poolDistributionEvent(): RewardPoolDistributionLoader {
-    return new RewardPoolDistributionLoader(
+  get poolTransfers(): RewardPoolTransferLoader {
+    return new RewardPoolTransferLoader(
       "App",
       this.get("id")!.toBytes().toHexString(),
-      "poolDistributionEvent",
-    );
-  }
-
-  get sustainabilityProof(): SustainabilityProofLoader {
-    return new SustainabilityProofLoader(
-      "App",
-      this.get("id")!.toBytes().toHexString(),
-      "sustainabilityProof",
+      "poolTransfers",
     );
   }
 
@@ -1060,9 +1036,9 @@ export class AppMetadata extends Entity {
 }
 
 export class AppRoundSummary extends Entity {
-  constructor(id: string) {
+  constructor(id: Bytes) {
     super();
-    this.set("id", Value.fromString(id));
+    this.set("id", Value.fromBytes(id));
   }
 
   save(): void {
@@ -1070,34 +1046,36 @@ export class AppRoundSummary extends Entity {
     assert(id != null, "Cannot save AppRoundSummary entity without an ID");
     if (id) {
       assert(
-        id.kind == ValueKind.STRING,
-        `Entities of type AppRoundSummary must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`,
+        id.kind == ValueKind.BYTES,
+        `Entities of type AppRoundSummary must have an ID of type Bytes but the id '${id.displayData()}' is of type ${id.displayKind()}`,
       );
-      store.set("AppRoundSummary", id.toString(), this);
+      store.set("AppRoundSummary", id.toBytes().toHexString(), this);
     }
   }
 
-  static loadInBlock(id: string): AppRoundSummary | null {
+  static loadInBlock(id: Bytes): AppRoundSummary | null {
     return changetype<AppRoundSummary | null>(
-      store.get_in_block("AppRoundSummary", id),
+      store.get_in_block("AppRoundSummary", id.toHexString()),
     );
   }
 
-  static load(id: string): AppRoundSummary | null {
-    return changetype<AppRoundSummary | null>(store.get("AppRoundSummary", id));
+  static load(id: Bytes): AppRoundSummary | null {
+    return changetype<AppRoundSummary | null>(
+      store.get("AppRoundSummary", id.toHexString()),
+    );
   }
 
-  get id(): string {
+  get id(): Bytes {
     let value = this.get("id");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
+  set id(value: Bytes) {
+    this.set("id", Value.fromBytes(value));
   }
 
   get app(): Bytes {
@@ -1272,22 +1250,22 @@ export class AppRoundSummary extends Entity {
   get poolWithdrawalsReasons(): AppRoundWithdrawalReasonLoader {
     return new AppRoundWithdrawalReasonLoader(
       "AppRoundSummary",
-      this.get("id")!.toString(),
+      this.get("id")!.toBytes().toHexString(),
       "poolWithdrawalsReasons",
     );
   }
 
-  get sustainabilityStats(): string {
+  get sustainabilityStats(): Bytes {
     let value = this.get("sustainabilityStats");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set sustainabilityStats(value: string) {
-    this.set("sustainabilityStats", Value.fromString(value));
+  set sustainabilityStats(value: Bytes) {
+    this.set("sustainabilityStats", Value.fromBytes(value));
   }
 
   get passportScore(): BigInt {
@@ -1350,17 +1328,17 @@ export class AppRoundWithdrawalReason extends Entity {
     this.set("id", Value.fromString(value));
   }
 
-  get appRoundSummary(): string {
+  get appRoundSummary(): Bytes {
     let value = this.get("appRoundSummary");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set appRoundSummary(value: string) {
-    this.set("appRoundSummary", Value.fromString(value));
+  set appRoundSummary(value: Bytes) {
+    this.set("appRoundSummary", Value.fromBytes(value));
   }
 
   get reason(): string {
@@ -1538,51 +1516,77 @@ export class AllocationResult extends Entity {
   }
 }
 
-export class AllocationVote extends Entity {
-  constructor(id: Int8) {
+export class StatsAllocationVote extends Entity {
+  constructor(id: string) {
     super();
-    this.set("id", Value.fromI64(id));
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
     let id = this.get("id");
-    assert(id != null, "Cannot save AllocationVote entity without an ID");
+    assert(id != null, "Cannot save StatsAllocationVote entity without an ID");
     if (id) {
       assert(
-        id.kind == ValueKind.INT8,
-        `Entities of type AllocationVote must have an ID of type Int8 but the id '${id.displayData()}' is of type ${id.displayKind()}`,
+        id.kind == ValueKind.STRING,
+        `Entities of type StatsAllocationVote must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`,
       );
-      store.set("AllocationVote", id.toI64().toString(), this);
+      store.set("StatsAllocationVote", id.toString(), this);
     }
   }
 
-  static loadInBlock(id: Int8): AllocationVote | null {
-    return changetype<AllocationVote | null>(
-      store.get_in_block("AllocationVote", id.toString()),
+  static loadInBlock(id: string): StatsAllocationVote | null {
+    return changetype<StatsAllocationVote | null>(
+      store.get_in_block("StatsAllocationVote", id),
     );
   }
 
-  static load(id: Int8): AllocationVote | null {
-    return changetype<AllocationVote | null>(
-      store.get("AllocationVote", id.toString()),
+  static load(id: string): StatsAllocationVote | null {
+    return changetype<StatsAllocationVote | null>(
+      store.get("StatsAllocationVote", id),
     );
   }
 
-  get id(): i64 {
+  get id(): string {
     let value = this.get("id");
     if (!value || value.kind == ValueKind.NULL) {
-      return 0;
+      throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toI64();
+      return value.toString();
     }
   }
 
-  set id(value: i64) {
-    this.set("id", Value.fromI64(value));
+  set id(value: string) {
+    this.set("id", Value.fromString(value));
   }
 
-  get voter(): Bytes {
-    let value = this.get("voter");
+  get interval(): string {
+    let value = this.get("interval");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toString();
+    }
+  }
+
+  set interval(value: string) {
+    this.set("interval", Value.fromString(value));
+  }
+
+  get timestamp(): BigInt {
+    let value = this.get("timestamp");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set timestamp(value: BigInt) {
+    this.set("timestamp", Value.fromBigInt(value));
+  }
+
+  get app(): Bytes {
+    let value = this.get("app");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
@@ -1590,21 +1594,8 @@ export class AllocationVote extends Entity {
     }
   }
 
-  set voter(value: Bytes) {
-    this.set("voter", Value.fromBytes(value));
-  }
-
-  get passport(): Bytes {
-    let value = this.get("passport");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set passport(value: Bytes) {
-    this.set("passport", Value.fromBytes(value));
+  set app(value: Bytes) {
+    this.set("app", Value.fromBytes(value));
   }
 
   get round(): string {
@@ -1620,17 +1611,17 @@ export class AllocationVote extends Entity {
     this.set("round", Value.fromString(value));
   }
 
-  get app(): Bytes {
-    let value = this.get("app");
+  get votes(): BigInt {
+    let value = this.get("votes");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toBytes();
+      return value.toBigInt();
     }
   }
 
-  set app(value: Bytes) {
-    this.set("app", Value.fromBytes(value));
+  set votes(value: BigInt) {
+    this.set("votes", Value.fromBigInt(value));
   }
 
   get weight(): BigDecimal {
@@ -1684,38 +1675,12 @@ export class AllocationVote extends Entity {
   set qfWeightExact(value: BigInt) {
     this.set("qfWeightExact", Value.fromBigInt(value));
   }
-
-  get timestamp(): i64 {
-    let value = this.get("timestamp");
-    if (!value || value.kind == ValueKind.NULL) {
-      return 0;
-    } else {
-      return value.toTimestamp();
-    }
-  }
-
-  set timestamp(value: i64) {
-    this.set("timestamp", Value.fromTimestamp(value));
-  }
-
-  get transaction(): string {
-    let value = this.get("transaction");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
-  }
 }
 
 export class RewardClaimed extends Entity {
-  constructor(id: string) {
+  constructor(id: Bytes) {
     super();
-    this.set("id", Value.fromString(id));
+    this.set("id", Value.fromBytes(id));
   }
 
   save(): void {
@@ -1723,34 +1688,36 @@ export class RewardClaimed extends Entity {
     assert(id != null, "Cannot save RewardClaimed entity without an ID");
     if (id) {
       assert(
-        id.kind == ValueKind.STRING,
-        `Entities of type RewardClaimed must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`,
+        id.kind == ValueKind.BYTES,
+        `Entities of type RewardClaimed must have an ID of type Bytes but the id '${id.displayData()}' is of type ${id.displayKind()}`,
       );
-      store.set("RewardClaimed", id.toString(), this);
+      store.set("RewardClaimed", id.toBytes().toHexString(), this);
     }
   }
 
-  static loadInBlock(id: string): RewardClaimed | null {
+  static loadInBlock(id: Bytes): RewardClaimed | null {
     return changetype<RewardClaimed | null>(
-      store.get_in_block("RewardClaimed", id),
+      store.get_in_block("RewardClaimed", id.toHexString()),
     );
   }
 
-  static load(id: string): RewardClaimed | null {
-    return changetype<RewardClaimed | null>(store.get("RewardClaimed", id));
+  static load(id: Bytes): RewardClaimed | null {
+    return changetype<RewardClaimed | null>(
+      store.get("RewardClaimed", id.toHexString()),
+    );
   }
 
-  get id(): string {
+  get id(): Bytes {
     let value = this.get("id");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
+  set id(value: Bytes) {
+    this.set("id", Value.fromBytes(value));
   }
 
   get emitter(): Bytes {
@@ -1831,17 +1798,17 @@ export class RewardClaimed extends Entity {
     this.set("timestamp", Value.fromBigInt(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 }
 
@@ -2195,22 +2162,6 @@ export class Account extends Entity {
     }
   }
 
-  get AllocationVotes(): AllocationVoteLoader {
-    return new AllocationVoteLoader(
-      "Account",
-      this.get("id")!.toBytes().toHexString(),
-      "AllocationVotes",
-    );
-  }
-
-  get ProposalVotes(): VoteReceiptLoader {
-    return new VoteReceiptLoader(
-      "Account",
-      this.get("id")!.toBytes().toHexString(),
-      "ProposalVotes",
-    );
-  }
-
   get B3TRRewards(): RewardClaimedLoader {
     return new RewardClaimedLoader(
       "Account",
@@ -2357,14 +2308,6 @@ export class Account extends Entity {
     );
   }
 
-  get delegateVotesChangedEvent(): DelegateVotesChangedLoader {
-    return new DelegateVotesChangedLoader(
-      "Account",
-      this.get("id")!.toBytes().toHexString(),
-      "delegateVotesChangedEvent",
-    );
-  }
-
   get asTimelock(): Bytes | null {
     let value = this.get("asTimelock");
     if (!value || value.kind == ValueKind.NULL) {
@@ -2412,14 +2355,6 @@ export class Account extends Entity {
       "Account",
       this.get("id")!.toBytes().toHexString(),
       "proposed",
-    );
-  }
-
-  get voted(): VoteReceiptLoader {
-    return new VoteReceiptLoader(
-      "Account",
-      this.get("id")!.toBytes().toHexString(),
-      "voted",
     );
   }
 
@@ -2487,14 +2422,6 @@ export class Account extends Entity {
     );
   }
 
-  get passportScores(): PassportScoreLoader {
-    return new PassportScoreLoader(
-      "Account",
-      this.get("id")!.toBytes().toHexString(),
-      "passportScores",
-    );
-  }
-
   get userSignals(): UserSignalLoader {
     return new UserSignalLoader(
       "Account",
@@ -2525,6 +2452,176 @@ export class Account extends Entity {
       this.get("id")!.toBytes().toHexString(),
       "asThorNode",
     );
+  }
+
+  get allocationVoteCount(): BigInt | null {
+    let value = this.get("allocationVoteCount");
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set allocationVoteCount(value: BigInt | null) {
+    if (!value) {
+      this.unset("allocationVoteCount");
+    } else {
+      this.set("allocationVoteCount", Value.fromBigInt(<BigInt>value));
+    }
+  }
+
+  get allocationVotesCastExact(): BigInt | null {
+    let value = this.get("allocationVotesCastExact");
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set allocationVotesCastExact(value: BigInt | null) {
+    if (!value) {
+      this.unset("allocationVotesCastExact");
+    } else {
+      this.set("allocationVotesCastExact", Value.fromBigInt(<BigInt>value));
+    }
+  }
+
+  get allocationQfWeightExact(): BigInt | null {
+    let value = this.get("allocationQfWeightExact");
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set allocationQfWeightExact(value: BigInt | null) {
+    if (!value) {
+      this.unset("allocationQfWeightExact");
+    } else {
+      this.set("allocationQfWeightExact", Value.fromBigInt(<BigInt>value));
+    }
+  }
+
+  get proposalVoteCount(): BigInt | null {
+    let value = this.get("proposalVoteCount");
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set proposalVoteCount(value: BigInt | null) {
+    if (!value) {
+      this.unset("proposalVoteCount");
+    } else {
+      this.set("proposalVoteCount", Value.fromBigInt(<BigInt>value));
+    }
+  }
+
+  get proposalVotesCast(): BigInt | null {
+    let value = this.get("proposalVotesCast");
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set proposalVotesCast(value: BigInt | null) {
+    if (!value) {
+      this.unset("proposalVotesCast");
+    } else {
+      this.set("proposalVotesCast", Value.fromBigInt(<BigInt>value));
+    }
+  }
+
+  get proposalWeightCast(): BigInt | null {
+    let value = this.get("proposalWeightCast");
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set proposalWeightCast(value: BigInt | null) {
+    if (!value) {
+      this.unset("proposalWeightCast");
+    } else {
+      this.set("proposalWeightCast", Value.fromBigInt(<BigInt>value));
+    }
+  }
+
+  get rewardClaimCount(): BigInt | null {
+    let value = this.get("rewardClaimCount");
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set rewardClaimCount(value: BigInt | null) {
+    if (!value) {
+      this.unset("rewardClaimCount");
+    } else {
+      this.set("rewardClaimCount", Value.fromBigInt(<BigInt>value));
+    }
+  }
+
+  get passportActionCount(): BigInt | null {
+    let value = this.get("passportActionCount");
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set passportActionCount(value: BigInt | null) {
+    if (!value) {
+      this.unset("passportActionCount");
+    } else {
+      this.set("passportActionCount", Value.fromBigInt(<BigInt>value));
+    }
+  }
+
+  get passportScoreTotal(): BigInt | null {
+    let value = this.get("passportScoreTotal");
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set passportScoreTotal(value: BigInt | null) {
+    if (!value) {
+      this.unset("passportScoreTotal");
+    } else {
+      this.set("passportScoreTotal", Value.fromBigInt(<BigInt>value));
+    }
+  }
+
+  get lastActivityTimestamp(): BigInt | null {
+    let value = this.get("lastActivityTimestamp");
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set lastActivityTimestamp(value: BigInt | null) {
+    if (!value) {
+      this.unset("lastActivityTimestamp");
+    } else {
+      this.set("lastActivityTimestamp", Value.fromBigInt(<BigInt>value));
+    }
   }
 }
 
@@ -2973,17 +3070,17 @@ export class ERC20Contract extends Entity {
     this.set("decimals", Value.fromI32(value));
   }
 
-  get totalSupply(): string {
+  get totalSupply(): Bytes {
     let value = this.get("totalSupply");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set totalSupply(value: string) {
-    this.set("totalSupply", Value.fromString(value));
+  set totalSupply(value: Bytes) {
+    this.set("totalSupply", Value.fromBytes(value));
   }
 
   get balances(): ERC20BalanceLoader {
@@ -3004,9 +3101,9 @@ export class ERC20Contract extends Entity {
 }
 
 export class VBDBalance extends Entity {
-  constructor(id: string) {
+  constructor(id: Bytes) {
     super();
-    this.set("id", Value.fromString(id));
+    this.set("id", Value.fromBytes(id));
   }
 
   save(): void {
@@ -3014,32 +3111,36 @@ export class VBDBalance extends Entity {
     assert(id != null, "Cannot save VBDBalance entity without an ID");
     if (id) {
       assert(
-        id.kind == ValueKind.STRING,
-        `Entities of type VBDBalance must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`,
+        id.kind == ValueKind.BYTES,
+        `Entities of type VBDBalance must have an ID of type Bytes but the id '${id.displayData()}' is of type ${id.displayKind()}`,
       );
-      store.set("VBDBalance", id.toString(), this);
+      store.set("VBDBalance", id.toBytes().toHexString(), this);
     }
   }
 
-  static loadInBlock(id: string): VBDBalance | null {
-    return changetype<VBDBalance | null>(store.get_in_block("VBDBalance", id));
+  static loadInBlock(id: Bytes): VBDBalance | null {
+    return changetype<VBDBalance | null>(
+      store.get_in_block("VBDBalance", id.toHexString()),
+    );
   }
 
-  static load(id: string): VBDBalance | null {
-    return changetype<VBDBalance | null>(store.get("VBDBalance", id));
+  static load(id: Bytes): VBDBalance | null {
+    return changetype<VBDBalance | null>(
+      store.get("VBDBalance", id.toHexString()),
+    );
   }
 
-  get id(): string {
+  get id(): Bytes {
     let value = this.get("id");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
+  set id(value: Bytes) {
+    this.set("id", Value.fromBytes(value));
   }
 
   get account(): Bytes | null {
@@ -3126,9 +3227,9 @@ export class VBDBalance extends Entity {
 }
 
 export class ERC20Balance extends Entity {
-  constructor(id: string) {
+  constructor(id: Bytes) {
     super();
-    this.set("id", Value.fromString(id));
+    this.set("id", Value.fromBytes(id));
   }
 
   save(): void {
@@ -3136,34 +3237,36 @@ export class ERC20Balance extends Entity {
     assert(id != null, "Cannot save ERC20Balance entity without an ID");
     if (id) {
       assert(
-        id.kind == ValueKind.STRING,
-        `Entities of type ERC20Balance must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`,
+        id.kind == ValueKind.BYTES,
+        `Entities of type ERC20Balance must have an ID of type Bytes but the id '${id.displayData()}' is of type ${id.displayKind()}`,
       );
-      store.set("ERC20Balance", id.toString(), this);
+      store.set("ERC20Balance", id.toBytes().toHexString(), this);
     }
   }
 
-  static loadInBlock(id: string): ERC20Balance | null {
+  static loadInBlock(id: Bytes): ERC20Balance | null {
     return changetype<ERC20Balance | null>(
-      store.get_in_block("ERC20Balance", id),
+      store.get_in_block("ERC20Balance", id.toHexString()),
     );
   }
 
-  static load(id: string): ERC20Balance | null {
-    return changetype<ERC20Balance | null>(store.get("ERC20Balance", id));
+  static load(id: Bytes): ERC20Balance | null {
+    return changetype<ERC20Balance | null>(
+      store.get("ERC20Balance", id.toHexString()),
+    );
   }
 
-  get id(): string {
+  get id(): Bytes {
     let value = this.get("id");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
+  set id(value: Bytes) {
+    this.set("id", Value.fromBytes(value));
   }
 
   get contract(): Bytes {
@@ -3224,9 +3327,9 @@ export class ERC20Balance extends Entity {
 }
 
 export class ERC20Approval extends Entity {
-  constructor(id: string) {
+  constructor(id: Bytes) {
     super();
-    this.set("id", Value.fromString(id));
+    this.set("id", Value.fromBytes(id));
   }
 
   save(): void {
@@ -3234,34 +3337,36 @@ export class ERC20Approval extends Entity {
     assert(id != null, "Cannot save ERC20Approval entity without an ID");
     if (id) {
       assert(
-        id.kind == ValueKind.STRING,
-        `Entities of type ERC20Approval must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`,
+        id.kind == ValueKind.BYTES,
+        `Entities of type ERC20Approval must have an ID of type Bytes but the id '${id.displayData()}' is of type ${id.displayKind()}`,
       );
-      store.set("ERC20Approval", id.toString(), this);
+      store.set("ERC20Approval", id.toBytes().toHexString(), this);
     }
   }
 
-  static loadInBlock(id: string): ERC20Approval | null {
+  static loadInBlock(id: Bytes): ERC20Approval | null {
     return changetype<ERC20Approval | null>(
-      store.get_in_block("ERC20Approval", id),
+      store.get_in_block("ERC20Approval", id.toHexString()),
     );
   }
 
-  static load(id: string): ERC20Approval | null {
-    return changetype<ERC20Approval | null>(store.get("ERC20Approval", id));
+  static load(id: Bytes): ERC20Approval | null {
+    return changetype<ERC20Approval | null>(
+      store.get("ERC20Approval", id.toHexString()),
+    );
   }
 
-  get id(): string {
+  get id(): Bytes {
     let value = this.get("id");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
+  set id(value: Bytes) {
+    this.set("id", Value.fromBytes(value));
   }
 
   get contract(): Bytes {
@@ -3420,14 +3525,6 @@ export class VotingContract extends Entity {
       "VotingContract",
       this.get("id")!.toBytes().toHexString(),
       "delegateChangedEvent",
-    );
-  }
-
-  get delegateVotesChangedEvent(): DelegateVotesChangedLoader {
-    return new DelegateVotesChangedLoader(
-      "VotingContract",
-      this.get("id")!.toBytes().toHexString(),
-      "delegateVotesChangedEvent",
     );
   }
 }
@@ -3602,14 +3699,6 @@ export class VoteWeight extends Entity {
   set value(value: BigInt) {
     this.set("value", Value.fromBigInt(value));
   }
-
-  get delegateVotesChangedEvent(): DelegateVotesChangedLoader {
-    return new DelegateVotesChangedLoader(
-      "VoteWeight",
-      this.get("id")!.toString(),
-      "delegateVotesChangedEvent",
-    );
-  }
 }
 
 export class DelegateChanged extends Entity {
@@ -3666,17 +3755,17 @@ export class DelegateChanged extends Entity {
     this.set("emitter", Value.fromBytes(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 
   get timestamp(): BigInt {
@@ -3759,158 +3848,6 @@ export class DelegateChanged extends Entity {
 
   set toDelegate(value: Bytes) {
     this.set("toDelegate", Value.fromBytes(value));
-  }
-}
-
-export class DelegateVotesChanged extends Entity {
-  constructor(id: string) {
-    super();
-    this.set("id", Value.fromString(id));
-  }
-
-  save(): void {
-    let id = this.get("id");
-    assert(id != null, "Cannot save DelegateVotesChanged entity without an ID");
-    if (id) {
-      assert(
-        id.kind == ValueKind.STRING,
-        `Entities of type DelegateVotesChanged must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`,
-      );
-      store.set("DelegateVotesChanged", id.toString(), this);
-    }
-  }
-
-  static loadInBlock(id: string): DelegateVotesChanged | null {
-    return changetype<DelegateVotesChanged | null>(
-      store.get_in_block("DelegateVotesChanged", id),
-    );
-  }
-
-  static load(id: string): DelegateVotesChanged | null {
-    return changetype<DelegateVotesChanged | null>(
-      store.get("DelegateVotesChanged", id),
-    );
-  }
-
-  get id(): string {
-    let value = this.get("id");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
-  }
-
-  get emitter(): Bytes {
-    let value = this.get("emitter");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set emitter(value: Bytes) {
-    this.set("emitter", Value.fromBytes(value));
-  }
-
-  get transaction(): string {
-    let value = this.get("transaction");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
-  }
-
-  get timestamp(): BigInt {
-    let value = this.get("timestamp");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value));
-  }
-
-  get voteWeight(): string | null {
-    let value = this.get("voteWeight");
-    if (!value || value.kind == ValueKind.NULL) {
-      return null;
-    } else {
-      return value.toString();
-    }
-  }
-
-  set voteWeight(value: string | null) {
-    if (!value) {
-      this.unset("voteWeight");
-    } else {
-      this.set("voteWeight", Value.fromString(<string>value));
-    }
-  }
-
-  get contract(): Bytes {
-    let value = this.get("contract");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set contract(value: Bytes) {
-    this.set("contract", Value.fromBytes(value));
-  }
-
-  get delegate(): Bytes {
-    let value = this.get("delegate");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set delegate(value: Bytes) {
-    this.set("delegate", Value.fromBytes(value));
-  }
-
-  get oldValue(): BigInt {
-    let value = this.get("oldValue");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set oldValue(value: BigInt) {
-    this.set("oldValue", Value.fromBigInt(value));
-  }
-
-  get newValue(): BigInt {
-    let value = this.get("newValue");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set newValue(value: BigInt) {
-    this.set("newValue", Value.fromBigInt(value));
   }
 }
 
@@ -4336,17 +4273,17 @@ export class TimelockOperationScheduled extends Entity {
     this.set("emitter", Value.fromBytes(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 
   get timestamp(): BigInt {
@@ -4461,17 +4398,17 @@ export class TimelockOperationExecuted extends Entity {
     this.set("emitter", Value.fromBytes(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 
   get timestamp(): BigInt {
@@ -4586,17 +4523,17 @@ export class TimelockOperationCancelled extends Entity {
     this.set("emitter", Value.fromBytes(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 
   get timestamp(): BigInt {
@@ -4698,17 +4635,17 @@ export class TimelockMinDelayChange extends Entity {
     this.set("emitter", Value.fromBytes(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 
   get timestamp(): BigInt {
@@ -4859,14 +4796,6 @@ export class Governor extends Entity {
       "Governor",
       this.get("id")!.toBytes().toHexString(),
       "proposalCanceled",
-    );
-  }
-
-  get votecast(): VoteCastLoader {
-    return new VoteCastLoader(
-      "Governor",
-      this.get("id")!.toBytes().toHexString(),
-      "votecast",
     );
   }
 }
@@ -5055,14 +4984,6 @@ export class Proposal extends Entity {
     );
   }
 
-  get receipts(): VoteReceiptLoader {
-    return new VoteReceiptLoader(
-      "Proposal",
-      this.get("id")!.toString(),
-      "receipts",
-    );
-  }
-
   get proposalCreated(): ProposalCreatedLoader {
     return new ProposalCreatedLoader(
       "Proposal",
@@ -5092,14 +5013,6 @@ export class Proposal extends Entity {
       "Proposal",
       this.get("id")!.toString(),
       "proposalCanceled",
-    );
-  }
-
-  get votecast(): VoteCastLoader {
-    return new VoteCastLoader(
-      "Proposal",
-      this.get("id")!.toString(),
-      "votecast",
     );
   }
 
@@ -5544,299 +5457,6 @@ export class ProposalSupport extends Entity {
   set power(value: BigInt) {
     this.set("power", Value.fromBigInt(value));
   }
-
-  get votes(): VoteReceiptLoader {
-    return new VoteReceiptLoader(
-      "ProposalSupport",
-      this.get("id")!.toString(),
-      "votes",
-    );
-  }
-}
-
-export class VoteReceipt extends Entity {
-  constructor(id: string) {
-    super();
-    this.set("id", Value.fromString(id));
-  }
-
-  save(): void {
-    let id = this.get("id");
-    assert(id != null, "Cannot save VoteReceipt entity without an ID");
-    if (id) {
-      assert(
-        id.kind == ValueKind.STRING,
-        `Entities of type VoteReceipt must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`,
-      );
-      store.set("VoteReceipt", id.toString(), this);
-    }
-  }
-
-  static loadInBlock(id: string): VoteReceipt | null {
-    return changetype<VoteReceipt | null>(
-      store.get_in_block("VoteReceipt", id),
-    );
-  }
-
-  static load(id: string): VoteReceipt | null {
-    return changetype<VoteReceipt | null>(store.get("VoteReceipt", id));
-  }
-
-  get id(): string {
-    let value = this.get("id");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
-  }
-
-  get proposal(): string {
-    let value = this.get("proposal");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set proposal(value: string) {
-    this.set("proposal", Value.fromString(value));
-  }
-
-  get voter(): Bytes {
-    let value = this.get("voter");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set voter(value: Bytes) {
-    this.set("voter", Value.fromBytes(value));
-  }
-
-  get support(): string {
-    let value = this.get("support");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set support(value: string) {
-    this.set("support", Value.fromString(value));
-  }
-
-  get weight(): BigInt {
-    let value = this.get("weight");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set weight(value: BigInt) {
-    this.set("weight", Value.fromBigInt(value));
-  }
-
-  get power(): BigInt {
-    let value = this.get("power");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set power(value: BigInt) {
-    this.set("power", Value.fromBigInt(value));
-  }
-
-  get reason(): string {
-    let value = this.get("reason");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set reason(value: string) {
-    this.set("reason", Value.fromString(value));
-  }
-
-  get params(): Bytes | null {
-    let value = this.get("params");
-    if (!value || value.kind == ValueKind.NULL) {
-      return null;
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set params(value: Bytes | null) {
-    if (!value) {
-      this.unset("params");
-    } else {
-      this.set("params", Value.fromBytes(<Bytes>value));
-    }
-  }
-}
-
-export class ProposalVote extends Entity {
-  constructor(id: Int8) {
-    super();
-    this.set("id", Value.fromI64(id));
-  }
-
-  save(): void {
-    let id = this.get("id");
-    assert(id != null, "Cannot save ProposalVote entity without an ID");
-    if (id) {
-      assert(
-        id.kind == ValueKind.INT8,
-        `Entities of type ProposalVote must have an ID of type Int8 but the id '${id.displayData()}' is of type ${id.displayKind()}`,
-      );
-      store.set("ProposalVote", id.toI64().toString(), this);
-    }
-  }
-
-  static loadInBlock(id: Int8): ProposalVote | null {
-    return changetype<ProposalVote | null>(
-      store.get_in_block("ProposalVote", id.toString()),
-    );
-  }
-
-  static load(id: Int8): ProposalVote | null {
-    return changetype<ProposalVote | null>(
-      store.get("ProposalVote", id.toString()),
-    );
-  }
-
-  get id(): i64 {
-    let value = this.get("id");
-    if (!value || value.kind == ValueKind.NULL) {
-      return 0;
-    } else {
-      return value.toI64();
-    }
-  }
-
-  set id(value: i64) {
-    this.set("id", Value.fromI64(value));
-  }
-
-  get timestamp(): i64 {
-    let value = this.get("timestamp");
-    if (!value || value.kind == ValueKind.NULL) {
-      return 0;
-    } else {
-      return value.toTimestamp();
-    }
-  }
-
-  set timestamp(value: i64) {
-    this.set("timestamp", Value.fromTimestamp(value));
-  }
-
-  get proposal(): string {
-    let value = this.get("proposal");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set proposal(value: string) {
-    this.set("proposal", Value.fromString(value));
-  }
-
-  get voter(): Bytes {
-    let value = this.get("voter");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set voter(value: Bytes) {
-    this.set("voter", Value.fromBytes(value));
-  }
-
-  get support(): string {
-    let value = this.get("support");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set support(value: string) {
-    this.set("support", Value.fromString(value));
-  }
-
-  get weight(): BigInt {
-    let value = this.get("weight");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set weight(value: BigInt) {
-    this.set("weight", Value.fromBigInt(value));
-  }
-
-  get power(): BigInt {
-    let value = this.get("power");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set power(value: BigInt) {
-    this.set("power", Value.fromBigInt(value));
-  }
-
-  get totalWeightCast(): BigInt {
-    let value = this.get("totalWeightCast");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set totalWeightCast(value: BigInt) {
-    this.set("totalWeightCast", Value.fromBigInt(value));
-  }
-
-  get totalPowerCast(): BigInt {
-    let value = this.get("totalPowerCast");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set totalPowerCast(value: BigInt) {
-    this.set("totalPowerCast", Value.fromBigInt(value));
-  }
 }
 
 export class ProposalCreated extends Entity {
@@ -5893,17 +5513,17 @@ export class ProposalCreated extends Entity {
     this.set("emitter", Value.fromBytes(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 
   get timestamp(): BigInt {
@@ -6013,17 +5633,17 @@ export class ProposalQueued extends Entity {
     this.set("emitter", Value.fromBytes(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 
   get timestamp(): BigInt {
@@ -6135,17 +5755,17 @@ export class ProposalExecuted extends Entity {
     this.set("emitter", Value.fromBytes(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 
   get timestamp(): BigInt {
@@ -6244,17 +5864,17 @@ export class ProposalCanceled extends Entity {
     this.set("emitter", Value.fromBytes(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 
   get timestamp(): BigInt {
@@ -6294,150 +5914,6 @@ export class ProposalCanceled extends Entity {
 
   set proposal(value: string) {
     this.set("proposal", Value.fromString(value));
-  }
-}
-
-export class VoteCast extends Entity {
-  constructor(id: string) {
-    super();
-    this.set("id", Value.fromString(id));
-  }
-
-  save(): void {
-    let id = this.get("id");
-    assert(id != null, "Cannot save VoteCast entity without an ID");
-    if (id) {
-      assert(
-        id.kind == ValueKind.STRING,
-        `Entities of type VoteCast must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`,
-      );
-      store.set("VoteCast", id.toString(), this);
-    }
-  }
-
-  static loadInBlock(id: string): VoteCast | null {
-    return changetype<VoteCast | null>(store.get_in_block("VoteCast", id));
-  }
-
-  static load(id: string): VoteCast | null {
-    return changetype<VoteCast | null>(store.get("VoteCast", id));
-  }
-
-  get id(): string {
-    let value = this.get("id");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
-  }
-
-  get emitter(): Bytes {
-    let value = this.get("emitter");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set emitter(value: Bytes) {
-    this.set("emitter", Value.fromBytes(value));
-  }
-
-  get transaction(): string {
-    let value = this.get("transaction");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
-  }
-
-  get timestamp(): BigInt {
-    let value = this.get("timestamp");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value));
-  }
-
-  get governor(): Bytes {
-    let value = this.get("governor");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set governor(value: Bytes) {
-    this.set("governor", Value.fromBytes(value));
-  }
-
-  get proposal(): string {
-    let value = this.get("proposal");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set proposal(value: string) {
-    this.set("proposal", Value.fromString(value));
-  }
-
-  get support(): string {
-    let value = this.get("support");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set support(value: string) {
-    this.set("support", Value.fromString(value));
-  }
-
-  get receipt(): string {
-    let value = this.get("receipt");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set receipt(value: string) {
-    this.set("receipt", Value.fromString(value));
-  }
-
-  get voter(): Bytes {
-    let value = this.get("voter");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set voter(value: Bytes) {
-    this.set("voter", Value.fromBytes(value));
   }
 }
 
@@ -6482,17 +5958,17 @@ export class ProposalDeposit extends Entity {
     this.set("id", Value.fromString(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 
   get emitter(): Bytes {
@@ -6562,9 +6038,9 @@ export class ProposalDeposit extends Entity {
 }
 
 export class Transaction extends Entity {
-  constructor(id: string) {
+  constructor(id: Bytes) {
     super();
-    this.set("id", Value.fromString(id));
+    this.set("id", Value.fromBytes(id));
   }
 
   save(): void {
@@ -6572,34 +6048,36 @@ export class Transaction extends Entity {
     assert(id != null, "Cannot save Transaction entity without an ID");
     if (id) {
       assert(
-        id.kind == ValueKind.STRING,
-        `Entities of type Transaction must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`,
+        id.kind == ValueKind.BYTES,
+        `Entities of type Transaction must have an ID of type Bytes but the id '${id.displayData()}' is of type ${id.displayKind()}`,
       );
-      store.set("Transaction", id.toString(), this);
+      store.set("Transaction", id.toBytes().toHexString(), this);
     }
   }
 
-  static loadInBlock(id: string): Transaction | null {
+  static loadInBlock(id: Bytes): Transaction | null {
     return changetype<Transaction | null>(
-      store.get_in_block("Transaction", id),
+      store.get_in_block("Transaction", id.toHexString()),
     );
   }
 
-  static load(id: string): Transaction | null {
-    return changetype<Transaction | null>(store.get("Transaction", id));
+  static load(id: Bytes): Transaction | null {
+    return changetype<Transaction | null>(
+      store.get("Transaction", id.toHexString()),
+    );
   }
 
-  get id(): string {
+  get id(): Bytes {
     let value = this.get("id");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
+  set id(value: Bytes) {
+    this.set("id", Value.fromBytes(value));
   }
 
   get timestamp(): BigInt {
@@ -6629,513 +6107,10 @@ export class Transaction extends Entity {
   }
 }
 
-export class RewardPoolDeposit extends Entity {
-  constructor(id: string) {
-    super();
-    this.set("id", Value.fromString(id));
-  }
-
-  save(): void {
-    let id = this.get("id");
-    assert(id != null, "Cannot save RewardPoolDeposit entity without an ID");
-    if (id) {
-      assert(
-        id.kind == ValueKind.STRING,
-        `Entities of type RewardPoolDeposit must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`,
-      );
-      store.set("RewardPoolDeposit", id.toString(), this);
-    }
-  }
-
-  static loadInBlock(id: string): RewardPoolDeposit | null {
-    return changetype<RewardPoolDeposit | null>(
-      store.get_in_block("RewardPoolDeposit", id),
-    );
-  }
-
-  static load(id: string): RewardPoolDeposit | null {
-    return changetype<RewardPoolDeposit | null>(
-      store.get("RewardPoolDeposit", id),
-    );
-  }
-
-  get id(): string {
-    let value = this.get("id");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
-  }
-
-  get transaction(): string {
-    let value = this.get("transaction");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
-  }
-
-  get emitter(): Bytes {
-    let value = this.get("emitter");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set emitter(value: Bytes) {
-    this.set("emitter", Value.fromBytes(value));
-  }
-
-  get timestamp(): BigInt {
-    let value = this.get("timestamp");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value));
-  }
-
-  get app(): Bytes {
-    let value = this.get("app");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set app(value: Bytes) {
-    this.set("app", Value.fromBytes(value));
-  }
-
-  get round(): string {
-    let value = this.get("round");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set round(value: string) {
-    this.set("round", Value.fromString(value));
-  }
-
-  get amount(): BigDecimal {
-    let value = this.get("amount");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigDecimal();
-    }
-  }
-
-  set amount(value: BigDecimal) {
-    this.set("amount", Value.fromBigDecimal(value));
-  }
-
-  get amountExact(): BigInt {
-    let value = this.get("amountExact");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set amountExact(value: BigInt) {
-    this.set("amountExact", Value.fromBigInt(value));
-  }
-
-  get depositor(): Bytes {
-    let value = this.get("depositor");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set depositor(value: Bytes) {
-    this.set("depositor", Value.fromBytes(value));
-  }
-}
-
-export class RewardPoolWithdraw extends Entity {
-  constructor(id: string) {
-    super();
-    this.set("id", Value.fromString(id));
-  }
-
-  save(): void {
-    let id = this.get("id");
-    assert(id != null, "Cannot save RewardPoolWithdraw entity without an ID");
-    if (id) {
-      assert(
-        id.kind == ValueKind.STRING,
-        `Entities of type RewardPoolWithdraw must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`,
-      );
-      store.set("RewardPoolWithdraw", id.toString(), this);
-    }
-  }
-
-  static loadInBlock(id: string): RewardPoolWithdraw | null {
-    return changetype<RewardPoolWithdraw | null>(
-      store.get_in_block("RewardPoolWithdraw", id),
-    );
-  }
-
-  static load(id: string): RewardPoolWithdraw | null {
-    return changetype<RewardPoolWithdraw | null>(
-      store.get("RewardPoolWithdraw", id),
-    );
-  }
-
-  get id(): string {
-    let value = this.get("id");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
-  }
-
-  get transaction(): string {
-    let value = this.get("transaction");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
-  }
-
-  get emitter(): Bytes {
-    let value = this.get("emitter");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set emitter(value: Bytes) {
-    this.set("emitter", Value.fromBytes(value));
-  }
-
-  get timestamp(): BigInt {
-    let value = this.get("timestamp");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value));
-  }
-
-  get app(): Bytes {
-    let value = this.get("app");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set app(value: Bytes) {
-    this.set("app", Value.fromBytes(value));
-  }
-
-  get round(): string {
-    let value = this.get("round");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set round(value: string) {
-    this.set("round", Value.fromString(value));
-  }
-
-  get amount(): BigDecimal {
-    let value = this.get("amount");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigDecimal();
-    }
-  }
-
-  set amount(value: BigDecimal) {
-    this.set("amount", Value.fromBigDecimal(value));
-  }
-
-  get amountExact(): BigInt {
-    let value = this.get("amountExact");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set amountExact(value: BigInt) {
-    this.set("amountExact", Value.fromBigInt(value));
-  }
-
-  get by(): Bytes {
-    let value = this.get("by");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set by(value: Bytes) {
-    this.set("by", Value.fromBytes(value));
-  }
-
-  get to(): Bytes {
-    let value = this.get("to");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set to(value: Bytes) {
-    this.set("to", Value.fromBytes(value));
-  }
-
-  get reason(): string {
-    let value = this.get("reason");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set reason(value: string) {
-    this.set("reason", Value.fromString(value));
-  }
-}
-
-export class RewardPoolDistribution extends Entity {
-  constructor(id: string) {
-    super();
-    this.set("id", Value.fromString(id));
-  }
-
-  save(): void {
-    let id = this.get("id");
-    assert(
-      id != null,
-      "Cannot save RewardPoolDistribution entity without an ID",
-    );
-    if (id) {
-      assert(
-        id.kind == ValueKind.STRING,
-        `Entities of type RewardPoolDistribution must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`,
-      );
-      store.set("RewardPoolDistribution", id.toString(), this);
-    }
-  }
-
-  static loadInBlock(id: string): RewardPoolDistribution | null {
-    return changetype<RewardPoolDistribution | null>(
-      store.get_in_block("RewardPoolDistribution", id),
-    );
-  }
-
-  static load(id: string): RewardPoolDistribution | null {
-    return changetype<RewardPoolDistribution | null>(
-      store.get("RewardPoolDistribution", id),
-    );
-  }
-
-  get id(): string {
-    let value = this.get("id");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
-  }
-
-  get transaction(): string {
-    let value = this.get("transaction");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
-  }
-
-  get emitter(): Bytes {
-    let value = this.get("emitter");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set emitter(value: Bytes) {
-    this.set("emitter", Value.fromBytes(value));
-  }
-
-  get timestamp(): BigInt {
-    let value = this.get("timestamp");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value));
-  }
-
-  get app(): Bytes {
-    let value = this.get("app");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set app(value: Bytes) {
-    this.set("app", Value.fromBytes(value));
-  }
-
-  get round(): string {
-    let value = this.get("round");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set round(value: string) {
-    this.set("round", Value.fromString(value));
-  }
-
-  get amount(): BigDecimal {
-    let value = this.get("amount");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigDecimal();
-    }
-  }
-
-  set amount(value: BigDecimal) {
-    this.set("amount", Value.fromBigDecimal(value));
-  }
-
-  get amountExact(): BigInt {
-    let value = this.get("amountExact");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set amountExact(value: BigInt) {
-    this.set("amountExact", Value.fromBigInt(value));
-  }
-
-  get by(): Bytes {
-    let value = this.get("by");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set by(value: Bytes) {
-    this.set("by", Value.fromBytes(value));
-  }
-
-  get to(): Bytes {
-    let value = this.get("to");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set to(value: Bytes) {
-    this.set("to", Value.fromBytes(value));
-  }
-
-  get proof(): string | null {
-    let value = this.get("proof");
-    if (!value || value.kind == ValueKind.NULL) {
-      return null;
-    } else {
-      return value.toString();
-    }
-  }
-
-  set proof(value: string | null) {
-    if (!value) {
-      this.unset("proof");
-    } else {
-      this.set("proof", Value.fromString(<string>value));
-    }
-  }
-}
-
 export class RewardPoolTransfer extends Entity {
-  constructor(id: string) {
+  constructor(id: Bytes) {
     super();
-    this.set("id", Value.fromString(id));
+    this.set("id", Value.fromBytes(id));
   }
 
   save(): void {
@@ -7143,49 +6118,49 @@ export class RewardPoolTransfer extends Entity {
     assert(id != null, "Cannot save RewardPoolTransfer entity without an ID");
     if (id) {
       assert(
-        id.kind == ValueKind.STRING,
-        `Entities of type RewardPoolTransfer must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`,
+        id.kind == ValueKind.BYTES,
+        `Entities of type RewardPoolTransfer must have an ID of type Bytes but the id '${id.displayData()}' is of type ${id.displayKind()}`,
       );
-      store.set("RewardPoolTransfer", id.toString(), this);
+      store.set("RewardPoolTransfer", id.toBytes().toHexString(), this);
     }
   }
 
-  static loadInBlock(id: string): RewardPoolTransfer | null {
+  static loadInBlock(id: Bytes): RewardPoolTransfer | null {
     return changetype<RewardPoolTransfer | null>(
-      store.get_in_block("RewardPoolTransfer", id),
+      store.get_in_block("RewardPoolTransfer", id.toHexString()),
     );
   }
 
-  static load(id: string): RewardPoolTransfer | null {
+  static load(id: Bytes): RewardPoolTransfer | null {
     return changetype<RewardPoolTransfer | null>(
-      store.get("RewardPoolTransfer", id),
+      store.get("RewardPoolTransfer", id.toHexString()),
     );
   }
 
-  get id(): string {
+  get id(): Bytes {
     let value = this.get("id");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
+  set id(value: Bytes) {
+    this.set("id", Value.fromBytes(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 
   get emitter(): Bytes {
@@ -7292,8 +6267,21 @@ export class RewardPoolTransfer extends Entity {
     this.set("to", Value.fromBytes(value));
   }
 
-  get deposit(): string | null {
-    let value = this.get("deposit");
+  get kind(): string {
+    let value = this.get("kind");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toString();
+    }
+  }
+
+  set kind(value: string) {
+    this.set("kind", Value.fromString(value));
+  }
+
+  get reason(): string | null {
+    let value = this.get("reason");
     if (!value || value.kind == ValueKind.NULL) {
       return null;
     } else {
@@ -7301,438 +6289,19 @@ export class RewardPoolTransfer extends Entity {
     }
   }
 
-  set deposit(value: string | null) {
+  set reason(value: string | null) {
     if (!value) {
-      this.unset("deposit");
+      this.unset("reason");
     } else {
-      this.set("deposit", Value.fromString(<string>value));
+      this.set("reason", Value.fromString(<string>value));
     }
-  }
-
-  get withdraw(): string | null {
-    let value = this.get("withdraw");
-    if (!value || value.kind == ValueKind.NULL) {
-      return null;
-    } else {
-      return value.toString();
-    }
-  }
-
-  set withdraw(value: string | null) {
-    if (!value) {
-      this.unset("withdraw");
-    } else {
-      this.set("withdraw", Value.fromString(<string>value));
-    }
-  }
-
-  get distribution(): string | null {
-    let value = this.get("distribution");
-    if (!value || value.kind == ValueKind.NULL) {
-      return null;
-    } else {
-      return value.toString();
-    }
-  }
-
-  set distribution(value: string | null) {
-    if (!value) {
-      this.unset("distribution");
-    } else {
-      this.set("distribution", Value.fromString(<string>value));
-    }
-  }
-}
-
-export class SustainabilityProof extends Entity {
-  constructor(id: string) {
-    super();
-    this.set("id", Value.fromString(id));
-  }
-
-  save(): void {
-    let id = this.get("id");
-    assert(id != null, "Cannot save SustainabilityProof entity without an ID");
-    if (id) {
-      assert(
-        id.kind == ValueKind.STRING,
-        `Entities of type SustainabilityProof must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`,
-      );
-      store.set("SustainabilityProof", id.toString(), this);
-    }
-  }
-
-  static loadInBlock(id: string): SustainabilityProof | null {
-    return changetype<SustainabilityProof | null>(
-      store.get_in_block("SustainabilityProof", id),
-    );
-  }
-
-  static load(id: string): SustainabilityProof | null {
-    return changetype<SustainabilityProof | null>(
-      store.get("SustainabilityProof", id),
-    );
-  }
-
-  get id(): string {
-    let value = this.get("id");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
-  }
-
-  get timestamp(): i64 {
-    let value = this.get("timestamp");
-    if (!value || value.kind == ValueKind.NULL) {
-      return 0;
-    } else {
-      return value.toTimestamp();
-    }
-  }
-
-  set timestamp(value: i64) {
-    this.set("timestamp", Value.fromTimestamp(value));
-  }
-
-  get app(): Bytes {
-    let value = this.get("app");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set app(value: Bytes) {
-    this.set("app", Value.fromBytes(value));
-  }
-
-  get round(): string {
-    let value = this.get("round");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set round(value: string) {
-    this.set("round", Value.fromString(value));
-  }
-
-  get account(): Bytes {
-    let value = this.get("account");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set account(value: Bytes) {
-    this.set("account", Value.fromBytes(value));
-  }
-
-  get proofType(): string | null {
-    let value = this.get("proofType");
-    if (!value || value.kind == ValueKind.NULL) {
-      return null;
-    } else {
-      return value.toString();
-    }
-  }
-
-  set proofType(value: string | null) {
-    if (!value) {
-      this.unset("proofType");
-    } else {
-      this.set("proofType", Value.fromString(<string>value));
-    }
-  }
-
-  get proofData(): string | null {
-    let value = this.get("proofData");
-    if (!value || value.kind == ValueKind.NULL) {
-      return null;
-    } else {
-      return value.toString();
-    }
-  }
-
-  set proofData(value: string | null) {
-    if (!value) {
-      this.unset("proofData");
-    } else {
-      this.set("proofData", Value.fromString(<string>value));
-    }
-  }
-
-  get description(): string | null {
-    let value = this.get("description");
-    if (!value || value.kind == ValueKind.NULL) {
-      return null;
-    } else {
-      return value.toString();
-    }
-  }
-
-  set description(value: string | null) {
-    if (!value) {
-      this.unset("description");
-    } else {
-      this.set("description", Value.fromString(<string>value));
-    }
-  }
-
-  get additionalInfo(): string | null {
-    let value = this.get("additionalInfo");
-    if (!value || value.kind == ValueKind.NULL) {
-      return null;
-    } else {
-      return value.toString();
-    }
-  }
-
-  set additionalInfo(value: string | null) {
-    if (!value) {
-      this.unset("additionalInfo");
-    } else {
-      this.set("additionalInfo", Value.fromString(<string>value));
-    }
-  }
-
-  get reward(): BigInt {
-    let value = this.get("reward");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set reward(value: BigInt) {
-    this.set("reward", Value.fromBigInt(value));
-  }
-
-  get transaction(): string {
-    let value = this.get("transaction");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
-  }
-
-  get carbon(): BigInt {
-    let value = this.get("carbon");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set carbon(value: BigInt) {
-    this.set("carbon", Value.fromBigInt(value));
-  }
-
-  get water(): BigInt {
-    let value = this.get("water");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set water(value: BigInt) {
-    this.set("water", Value.fromBigInt(value));
-  }
-
-  get energy(): BigInt {
-    let value = this.get("energy");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set energy(value: BigInt) {
-    this.set("energy", Value.fromBigInt(value));
-  }
-
-  get wasteMass(): BigInt {
-    let value = this.get("wasteMass");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set wasteMass(value: BigInt) {
-    this.set("wasteMass", Value.fromBigInt(value));
-  }
-
-  get plastic(): BigInt {
-    let value = this.get("plastic");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set plastic(value: BigInt) {
-    this.set("plastic", Value.fromBigInt(value));
-  }
-
-  get timber(): BigInt {
-    let value = this.get("timber");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set timber(value: BigInt) {
-    this.set("timber", Value.fromBigInt(value));
-  }
-
-  get educationTime(): BigInt {
-    let value = this.get("educationTime");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set educationTime(value: BigInt) {
-    this.set("educationTime", Value.fromBigInt(value));
-  }
-
-  get treesPlanted(): BigInt {
-    let value = this.get("treesPlanted");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set treesPlanted(value: BigInt) {
-    this.set("treesPlanted", Value.fromBigInt(value));
-  }
-
-  get caloriesBurned(): BigInt {
-    let value = this.get("caloriesBurned");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set caloriesBurned(value: BigInt) {
-    this.set("caloriesBurned", Value.fromBigInt(value));
-  }
-
-  get sleepQualityPercentage(): BigInt {
-    let value = this.get("sleepQualityPercentage");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set sleepQualityPercentage(value: BigInt) {
-    this.set("sleepQualityPercentage", Value.fromBigInt(value));
-  }
-
-  get cleanEnergyProduction(): BigInt {
-    let value = this.get("cleanEnergyProduction");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set cleanEnergyProduction(value: BigInt) {
-    this.set("cleanEnergyProduction", Value.fromBigInt(value));
-  }
-
-  get wasteItems(): BigInt {
-    let value = this.get("wasteItems");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set wasteItems(value: BigInt) {
-    this.set("wasteItems", Value.fromBigInt(value));
-  }
-
-  get people(): BigInt {
-    let value = this.get("people");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set people(value: BigInt) {
-    this.set("people", Value.fromBigInt(value));
-  }
-
-  get biodiversity(): BigInt {
-    let value = this.get("biodiversity");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set biodiversity(value: BigInt) {
-    this.set("biodiversity", Value.fromBigInt(value));
-  }
-
-  get version(): i32 {
-    let value = this.get("version");
-    if (!value || value.kind == ValueKind.NULL) {
-      return 0;
-    } else {
-      return value.toI32();
-    }
-  }
-
-  set version(value: i32) {
-    this.set("version", Value.fromI32(value));
   }
 }
 
 export class AccountSustainability extends Entity {
-  constructor(id: string) {
+  constructor(id: Bytes) {
     super();
-    this.set("id", Value.fromString(id));
+    this.set("id", Value.fromBytes(id));
   }
 
   save(): void {
@@ -7743,36 +6312,36 @@ export class AccountSustainability extends Entity {
     );
     if (id) {
       assert(
-        id.kind == ValueKind.STRING,
-        `Entities of type AccountSustainability must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`,
+        id.kind == ValueKind.BYTES,
+        `Entities of type AccountSustainability must have an ID of type Bytes but the id '${id.displayData()}' is of type ${id.displayKind()}`,
       );
-      store.set("AccountSustainability", id.toString(), this);
+      store.set("AccountSustainability", id.toBytes().toHexString(), this);
     }
   }
 
-  static loadInBlock(id: string): AccountSustainability | null {
+  static loadInBlock(id: Bytes): AccountSustainability | null {
     return changetype<AccountSustainability | null>(
-      store.get_in_block("AccountSustainability", id),
+      store.get_in_block("AccountSustainability", id.toHexString()),
     );
   }
 
-  static load(id: string): AccountSustainability | null {
+  static load(id: Bytes): AccountSustainability | null {
     return changetype<AccountSustainability | null>(
-      store.get("AccountSustainability", id),
+      store.get("AccountSustainability", id.toHexString()),
     );
   }
 
-  get id(): string {
+  get id(): Bytes {
     let value = this.get("id");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
+  set id(value: Bytes) {
+    this.set("id", Value.fromBytes(value));
   }
 
   get app(): Bytes {
@@ -7813,194 +6382,12 @@ export class AccountSustainability extends Entity {
   set account(value: Bytes) {
     this.set("account", Value.fromBytes(value));
   }
-
-  get carbon(): BigInt {
-    let value = this.get("carbon");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set carbon(value: BigInt) {
-    this.set("carbon", Value.fromBigInt(value));
-  }
-
-  get water(): BigInt {
-    let value = this.get("water");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set water(value: BigInt) {
-    this.set("water", Value.fromBigInt(value));
-  }
-
-  get energy(): BigInt {
-    let value = this.get("energy");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set energy(value: BigInt) {
-    this.set("energy", Value.fromBigInt(value));
-  }
-
-  get wasteMass(): BigInt {
-    let value = this.get("wasteMass");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set wasteMass(value: BigInt) {
-    this.set("wasteMass", Value.fromBigInt(value));
-  }
-
-  get plastic(): BigInt {
-    let value = this.get("plastic");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set plastic(value: BigInt) {
-    this.set("plastic", Value.fromBigInt(value));
-  }
-
-  get timber(): BigInt {
-    let value = this.get("timber");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set timber(value: BigInt) {
-    this.set("timber", Value.fromBigInt(value));
-  }
-
-  get educationTime(): BigInt {
-    let value = this.get("educationTime");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set educationTime(value: BigInt) {
-    this.set("educationTime", Value.fromBigInt(value));
-  }
-
-  get treesPlanted(): BigInt {
-    let value = this.get("treesPlanted");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set treesPlanted(value: BigInt) {
-    this.set("treesPlanted", Value.fromBigInt(value));
-  }
-
-  get caloriesBurned(): BigInt {
-    let value = this.get("caloriesBurned");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set caloriesBurned(value: BigInt) {
-    this.set("caloriesBurned", Value.fromBigInt(value));
-  }
-
-  get sleepQualityPercentage(): BigInt {
-    let value = this.get("sleepQualityPercentage");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set sleepQualityPercentage(value: BigInt) {
-    this.set("sleepQualityPercentage", Value.fromBigInt(value));
-  }
-
-  get cleanEnergyProduction(): BigInt {
-    let value = this.get("cleanEnergyProduction");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set cleanEnergyProduction(value: BigInt) {
-    this.set("cleanEnergyProduction", Value.fromBigInt(value));
-  }
-
-  get wasteItems(): BigInt {
-    let value = this.get("wasteItems");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set wasteItems(value: BigInt) {
-    this.set("wasteItems", Value.fromBigInt(value));
-  }
-
-  get people(): BigInt {
-    let value = this.get("people");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set people(value: BigInt) {
-    this.set("people", Value.fromBigInt(value));
-  }
-
-  get biodiversity(): BigInt {
-    let value = this.get("biodiversity");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set biodiversity(value: BigInt) {
-    this.set("biodiversity", Value.fromBigInt(value));
-  }
 }
 
 export class AccountRoundSustainability extends Entity {
-  constructor(id: string) {
+  constructor(id: Bytes) {
     super();
-    this.set("id", Value.fromString(id));
+    this.set("id", Value.fromBytes(id));
   }
 
   save(): void {
@@ -8011,36 +6398,36 @@ export class AccountRoundSustainability extends Entity {
     );
     if (id) {
       assert(
-        id.kind == ValueKind.STRING,
-        `Entities of type AccountRoundSustainability must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`,
+        id.kind == ValueKind.BYTES,
+        `Entities of type AccountRoundSustainability must have an ID of type Bytes but the id '${id.displayData()}' is of type ${id.displayKind()}`,
       );
-      store.set("AccountRoundSustainability", id.toString(), this);
+      store.set("AccountRoundSustainability", id.toBytes().toHexString(), this);
     }
   }
 
-  static loadInBlock(id: string): AccountRoundSustainability | null {
+  static loadInBlock(id: Bytes): AccountRoundSustainability | null {
     return changetype<AccountRoundSustainability | null>(
-      store.get_in_block("AccountRoundSustainability", id),
+      store.get_in_block("AccountRoundSustainability", id.toHexString()),
     );
   }
 
-  static load(id: string): AccountRoundSustainability | null {
+  static load(id: Bytes): AccountRoundSustainability | null {
     return changetype<AccountRoundSustainability | null>(
-      store.get("AccountRoundSustainability", id),
+      store.get("AccountRoundSustainability", id.toHexString()),
     );
   }
 
-  get id(): string {
+  get id(): Bytes {
     let value = this.get("id");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
+  set id(value: Bytes) {
+    this.set("id", Value.fromBytes(value));
   }
 
   get app(): Bytes {
@@ -8107,498 +6494,12 @@ export class AccountRoundSustainability extends Entity {
   set account(value: Bytes) {
     this.set("account", Value.fromBytes(value));
   }
-
-  get carbon(): BigInt {
-    let value = this.get("carbon");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set carbon(value: BigInt) {
-    this.set("carbon", Value.fromBigInt(value));
-  }
-
-  get water(): BigInt {
-    let value = this.get("water");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set water(value: BigInt) {
-    this.set("water", Value.fromBigInt(value));
-  }
-
-  get energy(): BigInt {
-    let value = this.get("energy");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set energy(value: BigInt) {
-    this.set("energy", Value.fromBigInt(value));
-  }
-
-  get wasteMass(): BigInt {
-    let value = this.get("wasteMass");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set wasteMass(value: BigInt) {
-    this.set("wasteMass", Value.fromBigInt(value));
-  }
-
-  get plastic(): BigInt {
-    let value = this.get("plastic");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set plastic(value: BigInt) {
-    this.set("plastic", Value.fromBigInt(value));
-  }
-
-  get timber(): BigInt {
-    let value = this.get("timber");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set timber(value: BigInt) {
-    this.set("timber", Value.fromBigInt(value));
-  }
-
-  get educationTime(): BigInt {
-    let value = this.get("educationTime");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set educationTime(value: BigInt) {
-    this.set("educationTime", Value.fromBigInt(value));
-  }
-
-  get treesPlanted(): BigInt {
-    let value = this.get("treesPlanted");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set treesPlanted(value: BigInt) {
-    this.set("treesPlanted", Value.fromBigInt(value));
-  }
-
-  get caloriesBurned(): BigInt {
-    let value = this.get("caloriesBurned");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set caloriesBurned(value: BigInt) {
-    this.set("caloriesBurned", Value.fromBigInt(value));
-  }
-
-  get sleepQualityPercentage(): BigInt {
-    let value = this.get("sleepQualityPercentage");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set sleepQualityPercentage(value: BigInt) {
-    this.set("sleepQualityPercentage", Value.fromBigInt(value));
-  }
-
-  get cleanEnergyProduction(): BigInt {
-    let value = this.get("cleanEnergyProduction");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set cleanEnergyProduction(value: BigInt) {
-    this.set("cleanEnergyProduction", Value.fromBigInt(value));
-  }
-
-  get wasteItems(): BigInt {
-    let value = this.get("wasteItems");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set wasteItems(value: BigInt) {
-    this.set("wasteItems", Value.fromBigInt(value));
-  }
-
-  get people(): BigInt {
-    let value = this.get("people");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set people(value: BigInt) {
-    this.set("people", Value.fromBigInt(value));
-  }
-
-  get biodiversity(): BigInt {
-    let value = this.get("biodiversity");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set biodiversity(value: BigInt) {
-    this.set("biodiversity", Value.fromBigInt(value));
-  }
-}
-
-export class AppSustainability extends Entity {
-  constructor(id: Int8) {
-    super();
-    this.set("id", Value.fromI64(id));
-  }
-
-  save(): void {
-    let id = this.get("id");
-    assert(id != null, "Cannot save AppSustainability entity without an ID");
-    if (id) {
-      assert(
-        id.kind == ValueKind.INT8,
-        `Entities of type AppSustainability must have an ID of type Int8 but the id '${id.displayData()}' is of type ${id.displayKind()}`,
-      );
-      store.set("AppSustainability", id.toI64().toString(), this);
-    }
-  }
-
-  static loadInBlock(id: Int8): AppSustainability | null {
-    return changetype<AppSustainability | null>(
-      store.get_in_block("AppSustainability", id.toString()),
-    );
-  }
-
-  static load(id: Int8): AppSustainability | null {
-    return changetype<AppSustainability | null>(
-      store.get("AppSustainability", id.toString()),
-    );
-  }
-
-  get id(): i64 {
-    let value = this.get("id");
-    if (!value || value.kind == ValueKind.NULL) {
-      return 0;
-    } else {
-      return value.toI64();
-    }
-  }
-
-  set id(value: i64) {
-    this.set("id", Value.fromI64(value));
-  }
-
-  get app(): Bytes {
-    let value = this.get("app");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set app(value: Bytes) {
-    this.set("app", Value.fromBytes(value));
-  }
-
-  get round(): string {
-    let value = this.get("round");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set round(value: string) {
-    this.set("round", Value.fromString(value));
-  }
-
-  get account(): Bytes {
-    let value = this.get("account");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set account(value: Bytes) {
-    this.set("account", Value.fromBytes(value));
-  }
-
-  get timestamp(): i64 {
-    let value = this.get("timestamp");
-    if (!value || value.kind == ValueKind.NULL) {
-      return 0;
-    } else {
-      return value.toTimestamp();
-    }
-  }
-
-  set timestamp(value: i64) {
-    this.set("timestamp", Value.fromTimestamp(value));
-  }
-
-  get reward(): BigInt {
-    let value = this.get("reward");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set reward(value: BigInt) {
-    this.set("reward", Value.fromBigInt(value));
-  }
-
-  get participantsCount(): BigInt {
-    let value = this.get("participantsCount");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set participantsCount(value: BigInt) {
-    this.set("participantsCount", Value.fromBigInt(value));
-  }
-
-  get carbon(): BigInt {
-    let value = this.get("carbon");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set carbon(value: BigInt) {
-    this.set("carbon", Value.fromBigInt(value));
-  }
-
-  get water(): BigInt {
-    let value = this.get("water");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set water(value: BigInt) {
-    this.set("water", Value.fromBigInt(value));
-  }
-
-  get energy(): BigInt {
-    let value = this.get("energy");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set energy(value: BigInt) {
-    this.set("energy", Value.fromBigInt(value));
-  }
-
-  get wasteMass(): BigInt {
-    let value = this.get("wasteMass");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set wasteMass(value: BigInt) {
-    this.set("wasteMass", Value.fromBigInt(value));
-  }
-
-  get plastic(): BigInt {
-    let value = this.get("plastic");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set plastic(value: BigInt) {
-    this.set("plastic", Value.fromBigInt(value));
-  }
-
-  get timber(): BigInt {
-    let value = this.get("timber");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set timber(value: BigInt) {
-    this.set("timber", Value.fromBigInt(value));
-  }
-
-  get educationTime(): BigInt {
-    let value = this.get("educationTime");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set educationTime(value: BigInt) {
-    this.set("educationTime", Value.fromBigInt(value));
-  }
-
-  get treesPlanted(): BigInt {
-    let value = this.get("treesPlanted");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set treesPlanted(value: BigInt) {
-    this.set("treesPlanted", Value.fromBigInt(value));
-  }
-
-  get caloriesBurned(): BigInt {
-    let value = this.get("caloriesBurned");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set caloriesBurned(value: BigInt) {
-    this.set("caloriesBurned", Value.fromBigInt(value));
-  }
-
-  get sleepQualityPercentage(): BigInt {
-    let value = this.get("sleepQualityPercentage");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set sleepQualityPercentage(value: BigInt) {
-    this.set("sleepQualityPercentage", Value.fromBigInt(value));
-  }
-
-  get cleanEnergyProduction(): BigInt {
-    let value = this.get("cleanEnergyProduction");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set cleanEnergyProduction(value: BigInt) {
-    this.set("cleanEnergyProduction", Value.fromBigInt(value));
-  }
-
-  get wasteItems(): BigInt {
-    let value = this.get("wasteItems");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set wasteItems(value: BigInt) {
-    this.set("wasteItems", Value.fromBigInt(value));
-  }
-
-  get people(): BigInt {
-    let value = this.get("people");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set people(value: BigInt) {
-    this.set("people", Value.fromBigInt(value));
-  }
-
-  get biodiversity(): BigInt {
-    let value = this.get("biodiversity");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set biodiversity(value: BigInt) {
-    this.set("biodiversity", Value.fromBigInt(value));
-  }
 }
 
 export class SustainabilityStats extends Entity {
-  constructor(id: string) {
+  constructor(id: Bytes) {
     super();
-    this.set("id", Value.fromString(id));
+    this.set("id", Value.fromBytes(id));
   }
 
   save(): void {
@@ -8606,36 +6507,36 @@ export class SustainabilityStats extends Entity {
     assert(id != null, "Cannot save SustainabilityStats entity without an ID");
     if (id) {
       assert(
-        id.kind == ValueKind.STRING,
-        `Entities of type SustainabilityStats must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`,
+        id.kind == ValueKind.BYTES,
+        `Entities of type SustainabilityStats must have an ID of type Bytes but the id '${id.displayData()}' is of type ${id.displayKind()}`,
       );
-      store.set("SustainabilityStats", id.toString(), this);
+      store.set("SustainabilityStats", id.toBytes().toHexString(), this);
     }
   }
 
-  static loadInBlock(id: string): SustainabilityStats | null {
+  static loadInBlock(id: Bytes): SustainabilityStats | null {
     return changetype<SustainabilityStats | null>(
-      store.get_in_block("SustainabilityStats", id),
+      store.get_in_block("SustainabilityStats", id.toHexString()),
     );
   }
 
-  static load(id: string): SustainabilityStats | null {
+  static load(id: Bytes): SustainabilityStats | null {
     return changetype<SustainabilityStats | null>(
-      store.get("SustainabilityStats", id),
+      store.get("SustainabilityStats", id.toHexString()),
     );
   }
 
-  get id(): string {
+  get id(): Bytes {
     let value = this.get("id");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
+  set id(value: Bytes) {
+    this.set("id", Value.fromBytes(value));
   }
 
   get rewards(): BigInt {
@@ -8688,188 +6589,6 @@ export class SustainabilityStats extends Entity {
 
   set actionCount(value: BigInt) {
     this.set("actionCount", Value.fromBigInt(value));
-  }
-
-  get carbon(): BigInt {
-    let value = this.get("carbon");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set carbon(value: BigInt) {
-    this.set("carbon", Value.fromBigInt(value));
-  }
-
-  get water(): BigInt {
-    let value = this.get("water");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set water(value: BigInt) {
-    this.set("water", Value.fromBigInt(value));
-  }
-
-  get energy(): BigInt {
-    let value = this.get("energy");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set energy(value: BigInt) {
-    this.set("energy", Value.fromBigInt(value));
-  }
-
-  get wasteMass(): BigInt {
-    let value = this.get("wasteMass");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set wasteMass(value: BigInt) {
-    this.set("wasteMass", Value.fromBigInt(value));
-  }
-
-  get plastic(): BigInt {
-    let value = this.get("plastic");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set plastic(value: BigInt) {
-    this.set("plastic", Value.fromBigInt(value));
-  }
-
-  get timber(): BigInt {
-    let value = this.get("timber");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set timber(value: BigInt) {
-    this.set("timber", Value.fromBigInt(value));
-  }
-
-  get educationTime(): BigInt {
-    let value = this.get("educationTime");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set educationTime(value: BigInt) {
-    this.set("educationTime", Value.fromBigInt(value));
-  }
-
-  get treesPlanted(): BigInt {
-    let value = this.get("treesPlanted");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set treesPlanted(value: BigInt) {
-    this.set("treesPlanted", Value.fromBigInt(value));
-  }
-
-  get caloriesBurned(): BigInt {
-    let value = this.get("caloriesBurned");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set caloriesBurned(value: BigInt) {
-    this.set("caloriesBurned", Value.fromBigInt(value));
-  }
-
-  get sleepQualityPercentage(): BigInt {
-    let value = this.get("sleepQualityPercentage");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set sleepQualityPercentage(value: BigInt) {
-    this.set("sleepQualityPercentage", Value.fromBigInt(value));
-  }
-
-  get cleanEnergyProduction(): BigInt {
-    let value = this.get("cleanEnergyProduction");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set cleanEnergyProduction(value: BigInt) {
-    this.set("cleanEnergyProduction", Value.fromBigInt(value));
-  }
-
-  get wasteItems(): BigInt {
-    let value = this.get("wasteItems");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set wasteItems(value: BigInt) {
-    this.set("wasteItems", Value.fromBigInt(value));
-  }
-
-  get people(): BigInt {
-    let value = this.get("people");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set people(value: BigInt) {
-    this.set("people", Value.fromBigInt(value));
-  }
-
-  get biodiversity(): BigInt {
-    let value = this.get("biodiversity");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set biodiversity(value: BigInt) {
-    this.set("biodiversity", Value.fromBigInt(value));
   }
 }
 
@@ -8955,17 +6674,17 @@ export class PassportDelegation extends Entity {
     this.set("delegatee", Value.fromBytes(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 
   get emitter(): Bytes {
@@ -9077,17 +6796,17 @@ export class PassportEntityLink extends Entity {
     this.set("passport", Value.fromBytes(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 
   get emitter(): Bytes {
@@ -9283,152 +7002,6 @@ export class PassportBlacklist extends Entity {
   }
 }
 
-export class PassportScore extends Entity {
-  constructor(id: string) {
-    super();
-    this.set("id", Value.fromString(id));
-  }
-
-  save(): void {
-    let id = this.get("id");
-    assert(id != null, "Cannot save PassportScore entity without an ID");
-    if (id) {
-      assert(
-        id.kind == ValueKind.STRING,
-        `Entities of type PassportScore must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`,
-      );
-      store.set("PassportScore", id.toString(), this);
-    }
-  }
-
-  static loadInBlock(id: string): PassportScore | null {
-    return changetype<PassportScore | null>(
-      store.get_in_block("PassportScore", id),
-    );
-  }
-
-  static load(id: string): PassportScore | null {
-    return changetype<PassportScore | null>(store.get("PassportScore", id));
-  }
-
-  get id(): string {
-    let value = this.get("id");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
-  }
-
-  get user(): Bytes {
-    let value = this.get("user");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set user(value: Bytes) {
-    this.set("user", Value.fromBytes(value));
-  }
-
-  get passport(): Bytes {
-    let value = this.get("passport");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set passport(value: Bytes) {
-    this.set("passport", Value.fromBytes(value));
-  }
-
-  get round(): string {
-    let value = this.get("round");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set round(value: string) {
-    this.set("round", Value.fromString(value));
-  }
-
-  get app(): Bytes {
-    let value = this.get("app");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set app(value: Bytes) {
-    this.set("app", Value.fromBytes(value));
-  }
-
-  get score(): BigInt {
-    let value = this.get("score");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set score(value: BigInt) {
-    this.set("score", Value.fromBigInt(value));
-  }
-
-  get transaction(): string {
-    let value = this.get("transaction");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toString();
-    }
-  }
-
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
-  }
-
-  get emitter(): Bytes {
-    let value = this.get("emitter");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBytes();
-    }
-  }
-
-  set emitter(value: Bytes) {
-    this.set("emitter", Value.fromBytes(value));
-  }
-
-  get timestamp(): BigInt {
-    let value = this.get("timestamp");
-    if (!value || value.kind == ValueKind.NULL) {
-      throw new Error("Cannot return null for a required field.");
-    } else {
-      return value.toBigInt();
-    }
-  }
-
-  set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value));
-  }
-}
-
 export class UserSignal extends Entity {
   constructor(id: string) {
     super();
@@ -9520,17 +7093,17 @@ export class UserSignal extends Entity {
     this.set("reason", Value.fromString(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 
   get emitter(): Bytes {
@@ -9658,17 +7231,17 @@ export class UserSignalsResetForApp extends Entity {
     this.set("reason", Value.fromString(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 
   get emitter(): Bytes {
@@ -9780,17 +7353,17 @@ export class UserSignalsReset extends Entity {
     this.set("reason", Value.fromString(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 
   get emitter(): Bytes {
@@ -9900,17 +7473,17 @@ export class NodeDelegation extends Entity {
     this.set("delegatee", Value.fromBytes(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 
   get emitter(): Bytes {
@@ -10141,17 +7714,17 @@ export class AppEndorsement extends Entity {
     this.set("app", Value.fromBytes(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 
   get emitter(): Bytes {
@@ -10794,17 +8367,17 @@ export class Lock2EarnTermAdded extends Entity {
     this.set("endTime", Value.fromBigInt(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 
   get emitter(): Bytes {
@@ -10903,17 +8476,17 @@ export class Lock2EarnTermClosed extends Entity {
     this.set("owner", Value.fromBytes(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 
   get emitter(): Bytes {
@@ -11025,17 +8598,17 @@ export class Lock2EarnTermRenewed extends Entity {
     this.set("newEndTime", Value.fromBigInt(value));
   }
 
-  get transaction(): string {
+  get transaction(): Bytes {
     let value = this.get("transaction");
     if (!value || value.kind == ValueKind.NULL) {
       throw new Error("Cannot return null for a required field.");
     } else {
-      return value.toString();
+      return value.toBytes();
     }
   }
 
-  set transaction(value: string) {
-    this.set("transaction", Value.fromString(value));
+  set transaction(value: Bytes) {
+    this.set("transaction", Value.fromBytes(value));
   }
 
   get emitter(): Bytes {
@@ -11156,7 +8729,7 @@ export class GMVoteLevelLoader extends Entity {
   }
 }
 
-export class RewardPoolDepositLoader extends Entity {
+export class RewardPoolTransferLoader extends Entity {
   _entity: string;
   _field: string;
   _id: string;
@@ -11168,63 +8741,9 @@ export class RewardPoolDepositLoader extends Entity {
     this._field = field;
   }
 
-  load(): RewardPoolDeposit[] {
+  load(): RewardPoolTransfer[] {
     let value = store.loadRelated(this._entity, this._id, this._field);
-    return changetype<RewardPoolDeposit[]>(value);
-  }
-}
-
-export class RewardPoolWithdrawLoader extends Entity {
-  _entity: string;
-  _field: string;
-  _id: string;
-
-  constructor(entity: string, id: string, field: string) {
-    super();
-    this._entity = entity;
-    this._id = id;
-    this._field = field;
-  }
-
-  load(): RewardPoolWithdraw[] {
-    let value = store.loadRelated(this._entity, this._id, this._field);
-    return changetype<RewardPoolWithdraw[]>(value);
-  }
-}
-
-export class RewardPoolDistributionLoader extends Entity {
-  _entity: string;
-  _field: string;
-  _id: string;
-
-  constructor(entity: string, id: string, field: string) {
-    super();
-    this._entity = entity;
-    this._id = id;
-    this._field = field;
-  }
-
-  load(): RewardPoolDistribution[] {
-    let value = store.loadRelated(this._entity, this._id, this._field);
-    return changetype<RewardPoolDistribution[]>(value);
-  }
-}
-
-export class SustainabilityProofLoader extends Entity {
-  _entity: string;
-  _field: string;
-  _id: string;
-
-  constructor(entity: string, id: string, field: string) {
-    super();
-    this._entity = entity;
-    this._id = id;
-    this._field = field;
-  }
-
-  load(): SustainabilityProof[] {
-    let value = store.loadRelated(this._entity, this._id, this._field);
-    return changetype<SustainabilityProof[]>(value);
+    return changetype<RewardPoolTransfer[]>(value);
   }
 }
 
@@ -11351,42 +8870,6 @@ export class ERC721TokenLoader extends Entity {
   load(): ERC721Token[] {
     let value = store.loadRelated(this._entity, this._id, this._field);
     return changetype<ERC721Token[]>(value);
-  }
-}
-
-export class AllocationVoteLoader extends Entity {
-  _entity: string;
-  _field: string;
-  _id: string;
-
-  constructor(entity: string, id: string, field: string) {
-    super();
-    this._entity = entity;
-    this._id = id;
-    this._field = field;
-  }
-
-  load(): AllocationVote[] {
-    let value = store.loadRelated(this._entity, this._id, this._field);
-    return changetype<AllocationVote[]>(value);
-  }
-}
-
-export class VoteReceiptLoader extends Entity {
-  _entity: string;
-  _field: string;
-  _id: string;
-
-  constructor(entity: string, id: string, field: string) {
-    super();
-    this._entity = entity;
-    this._id = id;
-    this._field = field;
-  }
-
-  load(): VoteReceipt[] {
-    let value = store.loadRelated(this._entity, this._id, this._field);
-    return changetype<VoteReceipt[]>(value);
   }
 }
 
@@ -11534,24 +9017,6 @@ export class DelegateChangedLoader extends Entity {
   }
 }
 
-export class DelegateVotesChangedLoader extends Entity {
-  _entity: string;
-  _field: string;
-  _id: string;
-
-  constructor(entity: string, id: string, field: string) {
-    super();
-    this._entity = entity;
-    this._id = id;
-    this._field = field;
-  }
-
-  load(): DelegateVotesChanged[] {
-    let value = store.loadRelated(this._entity, this._id, this._field);
-    return changetype<DelegateVotesChanged[]>(value);
-  }
-}
-
 export class TimelockCallLoader extends Entity {
   _entity: string;
   _field: string;
@@ -11657,24 +9122,6 @@ export class PassportEntityLinkLoader extends Entity {
   load(): PassportEntityLink[] {
     let value = store.loadRelated(this._entity, this._id, this._field);
     return changetype<PassportEntityLink[]>(value);
-  }
-}
-
-export class PassportScoreLoader extends Entity {
-  _entity: string;
-  _field: string;
-  _id: string;
-
-  constructor(entity: string, id: string, field: string) {
-    super();
-    this._entity = entity;
-    this._id = id;
-    this._field = field;
-  }
-
-  load(): PassportScore[] {
-    let value = store.loadRelated(this._entity, this._id, this._field);
-    return changetype<PassportScore[]>(value);
   }
 }
 
@@ -11873,24 +9320,6 @@ export class ProposalCanceledLoader extends Entity {
   load(): ProposalCanceled[] {
     let value = store.loadRelated(this._entity, this._id, this._field);
     return changetype<ProposalCanceled[]>(value);
-  }
-}
-
-export class VoteCastLoader extends Entity {
-  _entity: string;
-  _field: string;
-  _id: string;
-
-  constructor(entity: string, id: string, field: string) {
-    super();
-    this._entity = entity;
-    this._id = id;
-    this._field = field;
-  }
-
-  load(): VoteCast[] {
-    let value = store.loadRelated(this._entity, this._id, this._field);
-    return changetype<VoteCast[]>(value);
   }
 }
 

--- a/generated/templates.ts
+++ b/generated/templates.ts
@@ -21,13 +21,3 @@ export class ProposalMetadata extends DataSourceTemplate {
     DataSourceTemplate.createWithContext("ProposalMetadata", [cid], context);
   }
 }
-
-export class SustainabilityProof extends DataSourceTemplate {
-  static create(cid: string): void {
-    DataSourceTemplate.create("SustainabilityProof", [cid]);
-  }
-
-  static createWithContext(cid: string, context: DataSourceContext): void {
-    DataSourceTemplate.createWithContext("SustainabilityProof", [cid], context);
-  }
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,11 @@
       "dependencies": {
         "@graphprotocol/graph-cli": "^0.98.1",
         "@graphprotocol/graph-ts": "^0.38.2",
-        "@openzeppelin/subgraphs": "^0.1.8-5"
+        "@openzeppelin/subgraphs": "^0.1.8-5",
+        "source-map-support": "^0.5.21"
+      },
+      "devDependencies": {
+        "matchstick-as": "^0.6.0"
       }
     },
     "node_modules/@amxx/graphprotocol-utils": {
@@ -3752,6 +3756,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/matchstick-as": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/matchstick-as/-/matchstick-as-0.6.0.tgz",
+      "integrity": "sha512-E36fWsC1AbCkBFt05VsDDRoFvGSdcZg6oZJrtIe/YDBbuFh8SKbR5FcoqDhNWqSN+F7bN/iS2u8Md0SM+4pUpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "wabt": "1.0.24"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5065,6 +5079,24 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/wabt": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/wabt/-/wabt-1.0.24.tgz",
+      "integrity": "sha512-8l7sIOd3i5GWfTWciPL0+ff/FK/deVK2Q6FN+MPz4vfUcD78i2M/49XJTwF6aml91uIiuXJEsLKWMB2cw/mtKg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "wasm-decompile": "bin/wasm-decompile",
+        "wasm-interp": "bin/wasm-interp",
+        "wasm-objdump": "bin/wasm-objdump",
+        "wasm-opcodecnt": "bin/wasm-opcodecnt",
+        "wasm-strip": "bin/wasm-strip",
+        "wasm-validate": "bin/wasm-validate",
+        "wasm2c": "bin/wasm2c",
+        "wasm2wat": "bin/wasm2wat",
+        "wat2wasm": "bin/wat2wasm"
       }
     },
     "node_modules/wcwidth": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "deploy-dev": "graph deploy vebetter/dao-dev --ipfs $IPFS_NODE_URL --node $GRAPH_NODE_URL subgraph.yaml --version-label 1",
     "create": "graph create vebetter/dao --node $GRAPH_NODE_URL",
     "deploy": "graph deploy vebetter/dao --ipfs $IPFS_NODE_URL --node $GRAPH_NODE_URL subgraph.yaml --version-label 1",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "graph test",
     "codegen": "graph codegen subgraph.yaml",
     "build": "graph build subgraph.yaml",
     "create-local": "graph create sample/vebetterdao --node http://127.0.0.1:8020",
@@ -20,6 +20,10 @@
   "dependencies": {
     "@graphprotocol/graph-cli": "^0.98.1",
     "@graphprotocol/graph-ts": "^0.38.2",
-    "@openzeppelin/subgraphs": "^0.1.8-5"
+    "@openzeppelin/subgraphs": "^0.1.8-5",
+    "source-map-support": "^0.5.21"
+  },
+  "devDependencies": {
+    "matchstick-as": "^0.6.0"
   }
 }

--- a/src/Governor.ts
+++ b/src/Governor.ts
@@ -6,9 +6,6 @@ import {
 	ProposalExecuted,
 	ProposalCanceled,
 	ProposalDeposit,
-	VoteCast,
-	VoteReceipt,
-	ProposalVote
 } from '../generated/schema'
 import { ProposalMetadata as ProposalMetadataTemplate } from '../generated/templates'
 
@@ -24,13 +21,12 @@ import {
 import {
 	constants,
 	decimals,
-	events,
-	transactions,
 } from '@amxx/graphprotocol-utils'
 
 import {
 	fetchAccount,
-} from '../node_modules/@openzeppelin/subgraphs/src/fetch/account'
+	incrementAccountProposalActivity,
+} from './account'
 
 import {
 	fetchGovernor,
@@ -39,6 +35,7 @@ import {
 	fetchProposalSupport
 } from './fetch/governor'
 import { fetchRound } from './XAllocationVoting'
+import { ensureTransaction, eventEntityId } from './ids'
 
 export function handleProposalCreated(event: ProposalCreatedEvent): void {
 	ProposalMetadataTemplate.create(event.params.description)
@@ -65,9 +62,9 @@ export function handleProposalCreated(event: ProposalCreatedEvent): void {
 		call.save()
 	}
 
-	let ev = new ProposalCreated(events.id(event))
+	let ev = new ProposalCreated(eventEntityId(event))
 	ev.emitter = governor.id
-	ev.transaction = transactions.log(event).id
+	ev.transaction = ensureTransaction(event).id
 	ev.timestamp = event.block.timestamp
 	ev.governor = proposal.governor
 	ev.proposal = proposal.id
@@ -82,9 +79,9 @@ export function handleProposalQueued(event: ProposalQueuedEvent): void {
 	proposal.queued = true
 	proposal.save()
 
-	let ev = new ProposalQueued(events.id(event))
+	let ev = new ProposalQueued(eventEntityId(event))
 	ev.emitter = governor.id
-	ev.transaction = transactions.log(event).id
+	ev.transaction = ensureTransaction(event).id
 	ev.timestamp = event.block.timestamp
 	ev.governor = governor.id
 	ev.proposal = proposal.id
@@ -99,9 +96,9 @@ export function handleProposalExecuted(event: ProposalExecutedEvent): void {
 	proposal.executed = true
 	proposal.save()
 
-	let ev = new ProposalExecuted(events.id(event))
+	let ev = new ProposalExecuted(eventEntityId(event))
 	ev.emitter = governor.id
-	ev.transaction = transactions.log(event).id
+	ev.transaction = ensureTransaction(event).id
 	ev.timestamp = event.block.timestamp
 	ev.governor = governor.id
 	ev.proposal = proposal.id
@@ -115,9 +112,9 @@ export function handleProposalCanceled(event: ProposalCanceledEvent): void {
 	proposal.canceled = true
 	proposal.save()
 
-	let ev = new ProposalCanceled(events.id(event))
+	let ev = new ProposalCanceled(eventEntityId(event))
 	ev.emitter = governor.id
-	ev.transaction = transactions.log(event).id
+	ev.transaction = ensureTransaction(event).id
 	ev.timestamp = event.block.timestamp
 	ev.governor = governor.id
 	ev.proposal = proposal.id
@@ -128,55 +125,26 @@ export function handleVoteCast(event: VoteCastEvent): void {
 	let governor = fetchGovernor(event.address)
 	let proposal = fetchProposal(governor, event.params.proposalId)
 	let support = fetchProposalSupport(proposal, event.params.support)
+	let voter = fetchAccount(event.params.voter)
 	support.weight = support.weight.plus(event.params.weight)
 	support.power = support.power.plus(event.params.power)
 	support.voter = support.voter.plus(constants.BIGINT_ONE)
 	support.save()
 
-	const receiptId = ((event.block.number.toI64() * 10000000) + (event.transaction.index.toI64() * 10000) + event.transactionLogIndex.toI64())
-	const receipt = new VoteReceipt(receiptId.toString())
-	receipt.proposal = proposal.id
-	receipt.voter = fetchAccount(event.params.voter).id
-	receipt.support = support.id
-	receipt.weight = event.params.weight
-	receipt.power = event.params.power
-	receipt.reason = event.params.reason
-	receipt.save()
-	let ev = new VoteCast(events.id(event))
-	ev.emitter = governor.id
-	ev.transaction = transactions.log(event).id
-	ev.timestamp = event.block.timestamp
-	ev.governor = governor.id
-	ev.proposal = receipt.proposal
-	ev.support = receipt.support
-	ev.receipt = receipt.id.toString()
-	ev.voter = receipt.voter
-	ev.save()
-
 	proposal.voterCount = proposal.voterCount.plus(constants.BIGINT_ONE)
-	proposal.votesCast = proposal.votesCast.plus(receipt.weight)
-	proposal.weightCast = proposal.weightCast.plus(receipt.power)
+	proposal.votesCast = proposal.votesCast.plus(event.params.weight)
+	proposal.weightCast = proposal.weightCast.plus(event.params.power)
 	proposal.save()
-
-	const proposalVote = new ProposalVote(receiptId)
-	proposalVote.timestamp = event.block.timestamp.toI64()
-	proposalVote.proposal = receipt.proposal
-	proposalVote.voter = receipt.voter
-	proposalVote.support = receipt.support
-	proposalVote.weight = receipt.weight
-	proposalVote.power = receipt.power
-	proposalVote.totalPowerCast = proposal.weightCast
-	proposalVote.totalWeightCast = proposal.votesCast
-	proposalVote.save()
+	incrementAccountProposalActivity(voter, event.params.weight, event.params.power, event.block.timestamp)
 }
 
 export function handleProposalDeposit(event: ProposalDepositEvent): void {
 	let governor = fetchGovernor(event.address)
 	let proposal = fetchProposal(governor, event.params.proposalId)
 
-	let deposit = new ProposalDeposit(events.id(event))
+	let deposit = new ProposalDeposit(eventEntityId(event))
 	deposit.emitter = governor.id
-	deposit.transaction = transactions.log(event).id
+	deposit.transaction = ensureTransaction(event).id
 	deposit.timestamp = event.block.timestamp
 	deposit.depositor = fetchAccount(event.params.depositor).id
 	deposit.proposal = proposal.id

--- a/src/Lock2Earn.ts
+++ b/src/Lock2Earn.ts
@@ -13,11 +13,12 @@ import {
     Transfer as TransferEvent,
     Lock2Earn as Lock2EarnContract,
 } from '../generated/Lock2Earn/Lock2Earn'
-import { fetchAccount } from '../node_modules/@openzeppelin/subgraphs/src/fetch/account'
 import { decimals } from '@amxx/graphprotocol-utils'
 import { VeDelegate as VeDelegateContract } from '../generated/veDelegate/VeDelegate'
 import { VeDelegateAccount } from '../generated/schema'
 import { fetchVeDelegateAccount } from './VeDelegate'
+import { fetchAccount } from './account'
+import { ensureTransaction, eventEntityId } from './ids'
 
 const VE_DELEGATE_CONTRACT_ADDRESS = Address.fromString('0xfc32a9895C78CE00A1047d602Bd81Ea8134CC32b')
 
@@ -135,15 +136,15 @@ export function handleTermAdded(event: TermAddedEvent): void {
     stats.save()
 
     // Store event entity for analytics
-    let evt = new Lock2EarnTermAdded(event.transaction.hash.toHex() + '-' + event.logIndex.toString())
+    let evt = new Lock2EarnTermAdded(eventEntityId(event))
     evt.term = term.id
     evt.owner = owner.id
     evt.startTime = startTime
     evt.termLength = termLength
     evt.termInterval = termInterval
     evt.endTime = endTime
-    evt.transaction = event.transaction.hash.toHex()
-    evt.emitter = event.address
+    evt.transaction = ensureTransaction(event).id
+    evt.emitter = fetchAccount(event.address).id
     evt.timestamp = event.block.timestamp
     evt.save()
 }
@@ -173,11 +174,11 @@ export function handleTermClosed(event: TermClosedEvent): void {
     stats.totalRewards = decimals.toDecimals(stats.totalRewardsExact, 18)
     stats.save()
 
-    let evt = new Lock2EarnTermClosed(event.transaction.hash.toHex() + '-' + event.logIndex.toString())
+    let evt = new Lock2EarnTermClosed(eventEntityId(event))
     evt.term = term.id
     evt.owner = fetchAccount(event.params.owner).id
-    evt.transaction = event.transaction.hash.toHex()
-    evt.emitter = event.address
+    evt.transaction = ensureTransaction(event).id
+    evt.emitter = fetchAccount(event.address).id
     evt.timestamp = event.block.timestamp
     evt.save()
 }
@@ -270,12 +271,12 @@ export function handleTermRenewed(event: TermRenewedEvent): void {
     term.rewards = BigDecimal.zero()
     term.rewardsExact = BigInt.fromI32(0)
 
-    let evt = new Lock2EarnTermRenewed(event.transaction.hash.toHex() + '-' + event.logIndex.toString())
+    let evt = new Lock2EarnTermRenewed(eventEntityId(event))
     evt.term = term.id
     evt.owner = owner.id
     evt.newEndTime = endTime
-    evt.transaction = event.transaction.hash.toHex()
-    evt.emitter = event.address
+    evt.transaction = ensureTransaction(event).id
+    evt.emitter = fetchAccount(event.address).id
     evt.timestamp = event.block.timestamp
     evt.save()
 }

--- a/src/NodeManagement.ts
+++ b/src/NodeManagement.ts
@@ -2,11 +2,10 @@ import { NodeDelegation, VeDelegateAccount } from '../generated/schema'
 import {
     NodeDelegated as NodeDelegatedEvent,
 } from '../generated/NodeManagement/NodeManagement'
-import { fetchAccount } from '../node_modules/@openzeppelin/subgraphs/src/fetch/account'
-import { transactions } from '@amxx/graphprotocol-utils'
-import { store } from '@graphprotocol/graph-ts'
+import { fetchAccount } from './account'
 import { fetchNode } from './ThorNode'
 import { fetchStatsEndorsements } from './XApps'
+import { ensureTransaction } from './ids'
 
 export function handleDelegateNode(event: NodeDelegatedEvent): void {
     const id = [event.params.nodeId.toString(), 'delegation', 'node'].join('/').toString()
@@ -32,9 +31,9 @@ export function handleDelegateNode(event: NodeDelegatedEvent): void {
     delegation.delegatee = fetchAccount(event.params.delegatee).id
     delegation.active = event.params.delegated
 
-    delegation.emitter = event.address
+    delegation.emitter = fetchAccount(event.address).id
     delegation.timestamp = event.block.timestamp
-    delegation.transaction = transactions.log(event).id
+    delegation.transaction = ensureTransaction(event).id
     delegation.node = node.id
 
     delegation.save()

--- a/src/Passport.ts
+++ b/src/Passport.ts
@@ -1,4 +1,4 @@
-import { PassportDelegation, PassportEntityLink, VeDelegateAccount, PassportWhitelist, PassportBlacklist, PassportScore, UserSignal, UserSignalsReset, UserSignalsResetForApp } from '../generated/schema'
+import { PassportBlacklist, PassportDelegation, PassportEntityLink, PassportWhitelist, UserSignal, UserSignalsReset, UserSignalsResetForApp, VeDelegateAccount } from '../generated/schema'
 import {
     DelegationPending as DelegationPendingEvent,
     DelegationCreated as DelegationCreatedEvent,
@@ -15,14 +15,15 @@ import {
     UserSignalsReset as UserSignalsResetEvent,
     UserSignalsResetForApp as UserSignalsResetForAppEvent
 } from '../generated/passport/Passport'
-import { fetchAccount } from '../node_modules/@openzeppelin/subgraphs/src/fetch/account'
-import { transactions, events, constants } from '@amxx/graphprotocol-utils'
+import { constants } from '@amxx/graphprotocol-utils'
 import { store, Address, BigInt } from '@graphprotocol/graph-ts'
 import { fetchApp } from './XApps'
 import { fetchRound, fetchStatistic } from './XAllocationVoting'
 import { fetchAppRoundSummary, fetchAccountRoundSustainability } from './RewardsPool'
 import { XAllocationVoting } from '../generated/RewardsPool/XAllocationVoting'
 import { Passport } from '../generated/passport/Passport'
+import { ensureTransaction, eventEntityId } from './ids'
+import { fetchAccount, incrementAccountPassportActivity } from './account'
 
 export function handleDelegationPending(event: DelegationPendingEvent): void {
     const id = [event.params.delegator.toHexString(), event.params.delegatee.toHexString(), 'delegation'].join('/').toString()
@@ -35,9 +36,9 @@ export function handleDelegationPending(event: DelegationPendingEvent): void {
     passport.delegator = fetchAccount(event.params.delegator).id
     passport.active = false
 
-    passport.emitter = event.address
+    passport.emitter = fetchAccount(event.address).id
     passport.timestamp = event.block.timestamp
-    passport.transaction = transactions.log(event).id
+    passport.transaction = ensureTransaction(event).id
 
     passport.save()
 }
@@ -53,9 +54,9 @@ export function handleDelegationCreated(event: DelegationCreatedEvent): void {
     passport.delegator = fetchAccount(event.params.delegator).id
     passport.active = true
 
-    passport.emitter = event.address
+    passport.emitter = fetchAccount(event.address).id
     passport.timestamp = event.block.timestamp
-    passport.transaction = transactions.log(event).id
+    passport.transaction = ensureTransaction(event).id
 
     passport.save()
 
@@ -97,9 +98,9 @@ export function handleLinkPending(event: LinkPendingEvent): void {
     entityLink.entity = fetchAccount(event.params.entity).id
     entityLink.active = false
 
-    entityLink.emitter = event.address
+    entityLink.emitter = fetchAccount(event.address).id
     entityLink.timestamp = event.block.timestamp
-    entityLink.transaction = transactions.log(event).id
+    entityLink.transaction = ensureTransaction(event).id
 
     entityLink.save()
 }
@@ -115,9 +116,9 @@ export function handleLinkCreated(event: LinkCreatedEvent): void {
     entityLink.entity = fetchAccount(event.params.entity).id
     entityLink.active = true
 
-    entityLink.emitter = event.address
+    entityLink.emitter = fetchAccount(event.address).id
     entityLink.timestamp = event.block.timestamp
-    entityLink.transaction = transactions.log(event).id
+    entityLink.transaction = ensureTransaction(event).id
 
     entityLink.save()
 }
@@ -152,17 +153,11 @@ export function handleRegisteredAction(event: RegisteredActionEvent): void {
     stats.totalActionScores = stats.totalActionScores.plus(event.params.actionScore)
     stats.save()
 
-    const passportScore = new PassportScore(events.id(event))
-    passportScore.user = fetchAccount(event.params.user).id
-    passportScore.passport = fetchAccount(event.params.passport).id
-    passportScore.round = round.id
-    passportScore.app = app.id
-    passportScore.score = event.params.actionScore
-
-    passportScore.emitter = event.address
-    passportScore.transaction = transactions.log(event).id
-    passportScore.timestamp = event.block.timestamp
-    passportScore.save()
+    incrementAccountPassportActivity(
+        fetchAccount(event.params.passport),
+        event.params.actionScore,
+        event.block.timestamp,
+    )
 }
 
 export function handleUserWhitelisted(event: UserWhitelistedEvent): void {
@@ -223,15 +218,15 @@ export function handleUserSignaled(event: UserSignaledEvent): void {
     }
 
     signal.signalCount = signal.signalCount.plus(constants.BIGINT_ONE)
-    signal.emitter = event.address
+    signal.emitter = fetchAccount(event.address).id
     signal.timestamp = event.block.timestamp
-    signal.transaction = transactions.log(event).id
+    signal.transaction = ensureTransaction(event).id
 
     signal.save()
 }
 
 export function handleUserSignalsReset(event: UserSignalsResetEvent): void {
-    const reset = new UserSignalsReset(events.id(event))
+    const reset = new UserSignalsReset(eventEntityId(event))
     reset.user = fetchAccount(event.params.user).id
     reset.appsCount = constants.BIGINT_ZERO
     reset.reason = event.params.reason
@@ -239,9 +234,9 @@ export function handleUserSignalsReset(event: UserSignalsResetEvent): void {
     // Since we can't query all signals for a user directly in AssemblyScript,
     // we'll just create the reset event. The signals will be considered reset
     // when querying by checking if there's a reset event after their timestamp
-    reset.emitter = event.address
+    reset.emitter = fetchAccount(event.address).id
     reset.timestamp = event.block.timestamp
-    reset.transaction = transactions.log(event).id
+    reset.transaction = ensureTransaction(event).id
 
     reset.save()
 }
@@ -250,7 +245,7 @@ export function handleUserSignalsResetForApp(event: UserSignalsResetForAppEvent)
     const id = [event.params.user.toHexString(), event.params.app.toHexString()].join('/')
     const signal = UserSignal.load(id)
 
-    const reset = new UserSignalsResetForApp(events.id(event))
+    const reset = new UserSignalsResetForApp(eventEntityId(event))
     reset.user = fetchAccount(event.params.user).id
     reset.app = fetchApp(event.params.app).id
     reset.previousSignalCount = signal ? signal.signalCount : constants.BIGINT_ZERO
@@ -260,9 +255,9 @@ export function handleUserSignalsResetForApp(event: UserSignalsResetForAppEvent)
         store.remove('UserSignal', id)
     }
 
-    reset.emitter = event.address
+    reset.emitter = fetchAccount(event.address).id
     reset.timestamp = event.block.timestamp
-    reset.transaction = transactions.log(event).id
+    reset.transaction = ensureTransaction(event).id
 
     reset.save()
 }

--- a/src/Rewarder.ts
+++ b/src/Rewarder.ts
@@ -6,10 +6,11 @@ import {
 } from '../generated/rewarder/Rewarder'
 import { RewardClaimed, VeDelegateAccount, GMVoteLevel } from '../generated/schema'
 import { store, Entity } from '@graphprotocol/graph-ts'
-import { constants, decimals, transactions } from '@amxx/graphprotocol-utils'
+import { constants, decimals } from '@amxx/graphprotocol-utils'
 import { fetchRound, fetchStatistic } from './XAllocationVoting'
-import { fetchAccount } from '@openzeppelin/subgraphs/src/fetch/account'
 import { incrementLock2EarnTermRewards } from './Lock2Earn'
+import { fetchAccount, incrementAccountRewardClaims } from './account'
+import { ensureTransaction, eventBytesId } from './ids'
 
 export function handleReward(event: RewardClaimedEvent): void {
     const id = event.params.cycle.toString()
@@ -28,15 +29,17 @@ export function handleReward(event: RewardClaimedEvent): void {
         veDelegateStatistic.save()
     }
 
-    const ev = new RewardClaimed([event.params.voter.toHexString(), event.params.cycle.toString()].join('/'))
-    ev.emitter = event.address
-    ev.voter = fetchAccount(event.params.voter).id
+    const ev = new RewardClaimed(eventBytesId(event))
+    const voter = fetchAccount(event.params.voter)
+    ev.emitter = fetchAccount(event.address).id
+    ev.voter = voter.id
     ev.round = round.id
     ev.rewardExact = event.params.reward
     ev.reward = decimals.toDecimals(ev.rewardExact, 18)
     ev.timestamp = event.block.timestamp
-    ev.transaction = transactions.log(event).id
+    ev.transaction = ensureTransaction(event).id
     ev.save()
+    incrementAccountRewardClaims(voter, event.block.timestamp)
 }
 
 
@@ -62,15 +65,17 @@ export function handleReward2(event: RewardClaimedV2Event): void {
         incrementLock2EarnTermRewards(veAccount.lock2EarnTermId as string, event.params.reward.plus(event.params.gmReward))
     }
 
-    const ev = new RewardClaimed([event.params.voter.toHexString(), event.params.cycle.toString()].join('/'))
-    ev.emitter = event.address
-    ev.voter = fetchAccount(event.params.voter).id
+    const ev = new RewardClaimed(eventBytesId(event))
+    const voter = fetchAccount(event.params.voter)
+    ev.emitter = fetchAccount(event.address).id
+    ev.voter = voter.id
     ev.round = round.id
     ev.rewardExact = event.params.reward.plus(event.params.gmReward)
     ev.reward = decimals.toDecimals(ev.rewardExact, 18)
     ev.timestamp = event.block.timestamp
-    ev.transaction = transactions.log(event).id
+    ev.transaction = ensureTransaction(event).id
     ev.save()
+    incrementAccountRewardClaims(voter, event.block.timestamp)
 }
 
 

--- a/src/RewardsPool.ts
+++ b/src/RewardsPool.ts
@@ -1,7 +1,7 @@
 import {
     NewDeposit as NewDepositEvent,
-    TeamWithdrawal as TeamWithdrawalEvent,
     RewardDistributed as RewardDistributedEvent,
+    TeamWithdrawal as TeamWithdrawalEvent,
 } from '../generated/RewardsPool/RewardsPool'
 import {
     FundsDistributedToApp as FundsDistributedToAppEvent,
@@ -9,63 +9,72 @@ import {
 import {
     AllocationRewardsClaimed as AllocationRewardsClaimedEvent,
 } from '../generated/xallocationpool/XAllocationPool'
-import { App, AppRoundSummary, RewardPoolTransfer, RewardPoolDeposit, RewardPoolWithdraw, RewardPoolDistribution, SustainabilityProof, SustainabilityStats, AppSustainability, AccountSustainability, AccountRoundSustainability, Round, AppRoundWithdrawalReason } from '../generated/schema'
-import { events, transactions, decimals, constants } from '@amxx/graphprotocol-utils'
-import { DataSourceContext, JSONValueKind, Value, json, Bytes, dataSource, JSONValue, TypedMap, bigInt, Address, BigInt } from '@graphprotocol/graph-ts'
-import { fetchApp } from './XApps'
-import { fetchAccount } from '@openzeppelin/subgraphs/src/fetch/account'
-import { fetchRound } from './XAllocationVoting'
-import { SustainabilityProof as SustainabilityProofTemplate } from '../generated/templates'
-import { XAllocationVoting } from '../generated/RewardsPool/XAllocationVoting'
+import {
+    AccountRoundSustainability,
+    AccountSustainability,
+    App,
+    AppRoundSummary,
+    AppRoundWithdrawalReason,
+    CurrentRound,
+    RewardPoolTransfer,
+    Round,
+    SustainabilityStats,
+    VeDelegateAccount,
+} from '../generated/schema'
+import { Address, BigInt, Bytes, ethereum } from '@graphprotocol/graph-ts'
+import { constants, decimals } from '@amxx/graphprotocol-utils'
+
+import { fetchAccount } from './account'
+import {
+    accountRoundSustainabilityId,
+    accountSustainabilityId,
+    appRoundSummaryId,
+    ensureTransaction,
+    eventBytesId,
+    sustainabilityStatsId,
+} from './ids'
 import { incrementLock2EarnTermRewards } from './Lock2Earn'
-import { VeDelegateAccount } from '../generated/schema'
-import { CurrentRound } from '../generated/schema'
+import { fetchRound } from './XAllocationVoting'
+import { fetchApp } from './XApps'
 
-
+const X_ALLOCATION_POOL = Address.fromString('0x4191776f05f4be4848d3f4d587345078b439c7d3')
+const DYNAMIC_BASE_ALLOCATIONS = Address.fromString('0x98c1d097c39969bb5de754266f60d22bd105b368')
+const FIRST_PROOF_BACKED_DISTRIBUTION_BLOCK: i64 = 19145969
 
 export function handleNewDeposit(event: NewDepositEvent): void {
-    const ev = new RewardPoolDeposit(events.id(event))
+    const current = CurrentRound.load('singleton')
+    if (current == null) {
+        return
+    }
+
     const app = fetchApp(event.params.appId)
+    const round = fetchRound(current.roundId.toString())
+    const depositor = fetchAccount(event.params.depositor)
+    const zeroAccount = fetchAccount(Address.zero())
 
-    ev.emitter = event.address
-    ev.transaction = transactions.log(event).id
-    ev.timestamp = event.block.timestamp
-    ev.app = app.id
-    ev.amountExact = event.params.amount
-    ev.amount = decimals.toDecimals(event.params.amount, 18)
-    ev.depositor = fetchAccount(event.params.depositor).id
-    let current = CurrentRound.load("singleton")
-    if (current == null) { return }
-    ev.round = current.roundId.toString()
-    ev.save()
+    saveRewardPoolTransfer(
+        event,
+        app,
+        round,
+        event.params.amount,
+        depositor.id,
+        zeroAccount.id,
+        'DEPOSIT',
+        null,
+    )
 
-    const transfer = new RewardPoolTransfer(['transfer', events.id(event)].join('/'))
-    transfer.emitter = ev.emitter
-    transfer.transaction = ev.transaction
-    transfer.timestamp = ev.timestamp
-    transfer.app = ev.app
-    transfer.amountExact = ev.amountExact
-    transfer.amount = ev.amount
-    transfer.from = ev.depositor
-    transfer.to = Address.zero()
-    transfer.deposit = ev.id
-    transfer.round = ev.round
-    transfer.save()
-    updateAppRoundSummary(transfer)
+    updateAppRoundSummary(
+        fetchAppRoundSummary(app, round),
+        'DEPOSIT',
+        event.params.amount,
+        depositor.id,
+        null,
+    )
 
-    app.poolBalanceExact = app.poolBalanceExact.plus(ev.amountExact)
+    app.poolBalanceExact = app.poolBalanceExact.plus(event.params.amount)
 
-    // Check if this deposit is from the X Allocation Pool - if so, don't count it as a deposit
-    // since allocations are handled separately by the AllocationRewardsClaimed event handler
-    if (ev.depositor.equals(Address.fromString("0x4191776f05f4be4848d3f4d587345078b439c7d3"))) {
-        // This is an allocation, not a regular deposit - skip counting it here
-        // Allocations are tracked in handleAllocationRewardsClaimed
-    } else if (ev.depositor.equals(Address.fromString("0x98c1d097c39969bb5de754266f60d22bd105b368"))) {
-        // This is the overflow deposit that originally went into the Treasury and flows back to dApps as minimum allocation
-        // its tracked with FundsDistributedToApp events
-    } else {
-        // This is a regular deposit from a user/app
-        app.poolDepositsExact = app.poolDepositsExact.plus(ev.amountExact)
+    if (countsAsDeposit(depositor.id)) {
+        app.poolDepositsExact = app.poolDepositsExact.plus(event.params.amount)
     }
 
     app.poolBalance = decimals.toDecimals(app.poolBalanceExact, 18)
@@ -74,137 +83,79 @@ export function handleNewDeposit(event: NewDepositEvent): void {
 }
 
 export function handleTeamWithdrawal(event: TeamWithdrawalEvent): void {
-    const ev = new RewardPoolWithdraw(events.id(event))
     const app = fetchApp(event.params.appId)
+    const round = getCurrentRound()
+    const withdrawer = fetchAccount(event.params.withdrawer)
+    const teamWallet = fetchAccount(event.params.teamWallet)
 
-    ev.emitter = event.address
-    ev.transaction = transactions.log(event).id
-    ev.timestamp = event.block.timestamp
-    ev.app = app.id
-    ev.amountExact = event.params.amount
-    ev.amount = decimals.toDecimals(event.params.amount, 18)
-    ev.reason = event.params.reason
-    ev.to = fetchAccount(event.params.teamWallet).id
-    ev.by = fetchAccount(event.params.withdrawer).id
-    ev.round = getCurrentRound().id
-    ev.save()
+    saveRewardPoolTransfer(
+        event,
+        app,
+        round,
+        event.params.amount,
+        withdrawer.id,
+        teamWallet.id,
+        'WITHDRAW',
+        event.params.reason,
+    )
 
-    const transfer = new RewardPoolTransfer(['transfer', events.id(event)].join('/'))
-    transfer.emitter = ev.emitter
-    transfer.transaction = ev.transaction
-    transfer.timestamp = ev.timestamp
-    transfer.app = ev.app
-    transfer.amountExact = ev.amountExact
-    transfer.amount = ev.amount
-    transfer.from = ev.by
-    transfer.to = ev.to
-    transfer.withdraw = ev.id
-    transfer.round = ev.round
-    transfer.save()
-    updateAppRoundSummary(transfer)
+    updateAppRoundSummary(
+        fetchAppRoundSummary(app, round),
+        'WITHDRAW',
+        event.params.amount,
+        withdrawer.id,
+        event.params.reason,
+    )
 
-    app.poolBalanceExact = app.poolBalanceExact.minus(ev.amountExact)
-    app.poolWithdrawalsExact = app.poolWithdrawalsExact.plus(ev.amountExact)
+    app.poolBalanceExact = app.poolBalanceExact.minus(event.params.amount)
+    app.poolWithdrawalsExact = app.poolWithdrawalsExact.plus(event.params.amount)
     app.poolBalance = decimals.toDecimals(app.poolBalanceExact, 18)
     app.poolWithdrawals = decimals.toDecimals(app.poolWithdrawalsExact, 18)
     app.save()
 }
 
 export function handleRewardDistribution(event: RewardDistributedEvent): void {
-    const ev = new RewardPoolDistribution(events.id(event))
     const app = fetchApp(event.params.appId)
+    const round = getCurrentRound()
+    const distributor = fetchAccount(event.params.distributor)
+    const receiver = fetchAccount(event.params.receiver)
+    const appRoundSummary = fetchAppRoundSummary(app, round)
 
-    ev.emitter = event.address
-    ev.transaction = transactions.log(event).id
-    ev.timestamp = event.block.timestamp
-    ev.app = app.id
-    ev.amountExact = event.params.amount
-    ev.amount = decimals.toDecimals(event.params.amount, 18)
-    ev.to = fetchAccount(event.params.receiver).id
-    ev.by = fetchAccount(event.params.distributor).id
-    ev.round = getCurrentRound().id
-
-    const sustainabilityId = ((event.block.number.toI64() * 10000000) + (event.transaction.index.toI64() * 10000) + (event.transactionLogIndex.toI64() * 100))
-
-    /**
-     * the first valid proof is available with block #19145969
-     * ignore all data before
-     */
-    let isNewParticipant = false
     let isNewRoundParticipant = false
-    if (event.block.number.toI64() >= 19145969) {
-        if (event.params.proof.startsWith("ipfs://")) {
-            const context = new DataSourceContext()
-            context.set('proofId', Value.fromI64(sustainabilityId))
-            context.set('timestamp', Value.fromI64(event.block.timestamp.toI64()))
-            context.set('transaction', Value.fromString(transactions.log(event).id))
-            context.set('appId', Value.fromBytes(app.id))
-            context.set('accountId', Value.fromBytes(ev.to))
-            context.set('amount', Value.fromBigInt(event.params.amount))
-            context.set('sustainabilityId', Value.fromI64(sustainabilityId))
-            context.set('roundId', Value.fromString(ev.round))
-            SustainabilityProofTemplate.createWithContext(event.params.proof, context)
-            ev.proof = event.params.proof
+    if (event.block.number.toI64() >= FIRST_PROOF_BACKED_DISTRIBUTION_BLOCK) {
+        const participantStatus = updateAccountSustainability(receiver.id, app, round, event.params.amount)
+        if (participantStatus[0]) {
+            app.participantsCount = app.participantsCount.plus(constants.BIGINT_ONE)
         }
-        else if (event.params.proof) {
-            let proofData = json.try_fromString(event.params.proof)
-            if (!proofData.isError && proofData.value.kind == JSONValueKind.OBJECT) {
-                const proof = generateSustainabilityProofFromJson(sustainabilityId, proofData.value.toObject())
-                proof.reward = event.params.amount
-                proof.timestamp = event.block.timestamp.toI64()
-                proof.app = app.id
-                proof.account = ev.to
-                proof.transaction = transactions.log(event).id
-                proof.round = ev.round
-                proof.save()
-
-                updateAppSustainability(sustainabilityId, proof)
-
-                const newParticipantStatus = updateAccountSustainability(proof)
-                isNewParticipant = newParticipantStatus[0] ? true : false
-                isNewRoundParticipant = newParticipantStatus[1] ? true : false
-
-                updateAppRoundSustainability(proof)
-                ev.proof = proof.id
-            }
-        }
+        isNewRoundParticipant = participantStatus[1]
+        updateAppRoundSustainability(app, round, event.params.amount)
     }
 
-    ev.save()
+    saveRewardPoolTransfer(
+        event,
+        app,
+        round,
+        event.params.amount,
+        distributor.id,
+        receiver.id,
+        'DISTRIBUTION',
+        null,
+    )
 
-    const transfer = new RewardPoolTransfer(['transfer', events.id(event)].join('/'))
-    transfer.emitter = ev.emitter
-    transfer.transaction = ev.transaction
-    transfer.timestamp = ev.timestamp
-    transfer.app = ev.app
-    transfer.amountExact = ev.amountExact
-    transfer.amount = ev.amount
-    transfer.from = ev.by
-    transfer.to = ev.to
-    transfer.distribution = ev.id
-    transfer.round = ev.round
-    transfer.save()
-    updateAppRoundSummary(transfer)
+    updateAppRoundSummary(appRoundSummary, 'DISTRIBUTION', event.params.amount, distributor.id, null)
 
-    app.poolBalanceExact = app.poolBalanceExact.minus(ev.amountExact)
-    app.poolDistributionsExact = app.poolDistributionsExact.plus(ev.amountExact)
+    app.poolBalanceExact = app.poolBalanceExact.minus(event.params.amount)
+    app.poolDistributionsExact = app.poolDistributionsExact.plus(event.params.amount)
     app.poolBalance = decimals.toDecimals(app.poolBalanceExact, 18)
     app.poolDistributions = decimals.toDecimals(app.poolDistributionsExact, 18)
-
-    if (isNewParticipant) {
-        app.participantsCount = app.participantsCount.plus(constants.BIGINT_ONE)
-    }
-
     app.save()
 
     if (isNewRoundParticipant) {
-        const appRoundSummary = AppRoundSummary.load([app.id.toHexString(), ev.round].join('/'))!
         appRoundSummary.activeUserCount = appRoundSummary.activeUserCount.plus(constants.BIGINT_ONE)
         appRoundSummary.save()
     }
 
-    // Wire in Lock2Earn reward increment
-    let veAccount = VeDelegateAccount.load(event.params.receiver)
+    const veAccount = VeDelegateAccount.load(event.params.receiver)
     if (veAccount && veAccount.asLock2EarnTerm && veAccount.lock2EarnTermId != null) {
         incrementLock2EarnTermRewards(veAccount.lock2EarnTermId as string, event.params.amount)
     }
@@ -212,17 +163,12 @@ export function handleRewardDistribution(event: RewardDistributedEvent): void {
 
 export function handleAllocationRewardsClaimed(event: AllocationRewardsClaimedEvent): void {
     const app = fetchApp(event.params.appId)
+    const nextRound = fetchRound(event.params.roundId.plus(constants.BIGINT_ONE).toString())
 
-    // Add 1 to the roundId because thats thats the round where the allocation will be used
-    const nextRoundId = event.params.roundId.plus(constants.BIGINT_ONE)
-    const nextRound = fetchRound(nextRoundId.toString())
-
-    // Update app allocation amounts using the event data
     app.poolAllocationsExact = app.poolAllocationsExact.plus(event.params.totalAmount)
     app.poolAllocations = decimals.toDecimals(app.poolAllocationsExact, 18)
     app.save()
 
-    // Update app round summary allocation amounts
     const appRoundSummary = fetchAppRoundSummary(app, nextRound)
     appRoundSummary.poolAllocationsExact = appRoundSummary.poolAllocationsExact.plus(event.params.totalAmount)
     appRoundSummary.poolAllocations = decimals.toDecimals(appRoundSummary.poolAllocationsExact, 18)
@@ -233,420 +179,162 @@ export function handleFundsDistributedToApp(event: FundsDistributedToAppEvent): 
     const app = fetchApp(event.params.appId)
     const round = fetchRound(event.params.roundId.toString())
 
-    // Update app allocation amounts using the event data
     app.poolAllocationsExact = app.poolAllocationsExact.plus(event.params.amount)
     app.poolAllocations = decimals.toDecimals(app.poolAllocationsExact, 18)
     app.save()
 
-    // Update app round summary allocation amounts
     const appRoundSummary = fetchAppRoundSummary(app, round)
     appRoundSummary.poolAllocationsExact = appRoundSummary.poolAllocationsExact.plus(event.params.amount)
     appRoundSummary.poolAllocations = decimals.toDecimals(appRoundSummary.poolAllocationsExact, 18)
     appRoundSummary.save()
 }
 
-
-export function handleSustainabilityProof(content: Bytes, context: DataSourceContext): void {
-    const jsonData = json.try_fromBytes(content)
-    if (jsonData.isError || jsonData.value.kind !== JSONValueKind.OBJECT) { return }
-    const proof = generateSustainabilityProofFromJson(context.get('proofId')!.toI64(), jsonData.value.toObject())
-    proof.timestamp = context.get('timestamp')!.toI64()
-    proof.transaction = context.get('transaction')!.toString()
-    proof.account = context.get('accountId')!.toBytes()
-    proof.app = context.get('appId')!.toBytes()
-    proof.reward = context.get('amount')!.toBigInt()
-    proof.round = context.get('roundId')!.toString()
-    proof.save()
-
-    updateAppSustainability(context.get('sustainabilityId')!.toI64(), proof)
-    const newParticipantStatus = updateAccountSustainability(proof)
-    if (newParticipantStatus[0]) {
-        const app = App.load(proof.app)!
-        app.participantsCount = app.participantsCount.plus(constants.BIGINT_ONE)
-        app.save()
-    }
-
-    if (newParticipantStatus[1]) {
-        const appRoundSummary = AppRoundSummary.load([proof.app.toHexString(), proof.round].join('/'))!
-        appRoundSummary.activeUserCount = appRoundSummary.activeUserCount.plus(constants.BIGINT_ONE)
-        appRoundSummary.save()
-    }
-    updateAppRoundSustainability(proof)
+function saveRewardPoolTransfer(
+    event: ethereum.Event,
+    app: App,
+    round: Round,
+    amountExact: BigInt,
+    from: Bytes,
+    to: Bytes,
+    kind: string,
+    reason: string | null,
+): void {
+    const transfer = new RewardPoolTransfer(eventBytesId(event))
+    transfer.transaction = ensureTransaction(event).id
+    transfer.emitter = fetchAccount(event.address).id
+    transfer.timestamp = event.block.timestamp
+    transfer.app = app.id
+    transfer.round = round.id
+    transfer.amountExact = amountExact
+    transfer.amount = decimals.toDecimals(amountExact, 18)
+    transfer.from = from
+    transfer.to = to
+    transfer.kind = kind
+    transfer.reason = reason
+    transfer.save()
 }
 
-function updateAppRoundSustainability(proof: SustainabilityProof): void {
-    const id = [proof.app.toHexString(), proof.round].join('/')
-    const sustainabilityStats = SustainabilityStats.load(id)
-    if (!sustainabilityStats) { return }
+function updateAppRoundSustainability(app: App, round: Round, reward: BigInt): void {
+    const sustainabilityStats = SustainabilityStats.load(sustainabilityStatsId(app.id, round.id))
+    if (sustainabilityStats == null) {
+        return
+    }
 
-    const app = App.load(proof.app)!
     sustainabilityStats.newUserCount = app.participantsCount.minus(sustainabilityStats.participantsCountStart)
-    sustainabilityStats.rewards = sustainabilityStats.rewards.plus(proof.reward)
+    sustainabilityStats.rewards = sustainabilityStats.rewards.plus(reward)
     sustainabilityStats.actionCount = sustainabilityStats.actionCount.plus(constants.BIGINT_ONE)
-
-    sustainabilityStats.carbon = sustainabilityStats.carbon.plus(proof.carbon)
-    sustainabilityStats.water = sustainabilityStats.water.plus(proof.water)
-    sustainabilityStats.energy = sustainabilityStats.energy.plus(proof.energy)
-    sustainabilityStats.wasteMass = sustainabilityStats.wasteMass.plus(proof.wasteMass)
-    sustainabilityStats.plastic = sustainabilityStats.plastic.plus(proof.plastic)
-    sustainabilityStats.timber = sustainabilityStats.timber.plus(proof.timber)
-    sustainabilityStats.educationTime = sustainabilityStats.educationTime.plus(proof.educationTime)
-    sustainabilityStats.treesPlanted = sustainabilityStats.treesPlanted.plus(proof.treesPlanted)
-    sustainabilityStats.caloriesBurned = sustainabilityStats.caloriesBurned.plus(proof.caloriesBurned)
-    sustainabilityStats.sleepQualityPercentage = sustainabilityStats.sleepQualityPercentage.plus(proof.sleepQualityPercentage)
-    sustainabilityStats.cleanEnergyProduction = sustainabilityStats.cleanEnergyProduction.plus(proof.cleanEnergyProduction)
-
-    // deprecated entries
-    sustainabilityStats.wasteItems = sustainabilityStats.wasteItems.plus(proof.wasteItems)
-    sustainabilityStats.people = sustainabilityStats.people.plus(proof.people)
-    sustainabilityStats.biodiversity = sustainabilityStats.biodiversity.plus(proof.biodiversity)
     sustainabilityStats.save()
 }
 
-function generateSustainabilityProofFromJson(id: i64, proofObject: TypedMap<string, JSONValue>): SustainabilityProof {
-    const proof = new SustainabilityProof(id.toString())
-
-    proof.reward = constants.BIGINT_ZERO
-    proof.carbon = constants.BIGINT_ZERO
-    proof.water = constants.BIGINT_ZERO
-    proof.energy = constants.BIGINT_ZERO
-    proof.wasteMass = constants.BIGINT_ZERO
-    proof.plastic = constants.BIGINT_ZERO
-    proof.timber = constants.BIGINT_ZERO
-    proof.educationTime = constants.BIGINT_ZERO
-    proof.treesPlanted = constants.BIGINT_ZERO
-    proof.caloriesBurned = constants.BIGINT_ZERO
-    proof.sleepQualityPercentage = constants.BIGINT_ZERO
-    proof.cleanEnergyProduction = constants.BIGINT_ZERO
-
-    // deprecated entries
-    proof.wasteItems = constants.BIGINT_ZERO
-    proof.people = constants.BIGINT_ZERO
-    proof.biodiversity = constants.BIGINT_ZERO
-    proof.version = 0
-
-    /**
-     * Proof Version 2
-     *
-     * Introduced with https://github.com/vechain/vebetterdao-contracts/pull/18 
-     *
-     * Example JSON:
-     * {
-     *     version: 2,
-     *     description: 'The description of the action',
-     *     proof: { image: 'https://image.png', link: 'https://twitter.com/tweet/1' },
-     *     impact: { carbon: 100, water: 200 }
-     * }
-     */
-    if (proofObject.isSet("version") && proofObject.get("version")!.kind === JSONValueKind.NUMBER && proofObject.get("version")!.toI64() == 2) {
-        proof.version = 2
-
-        if (proofObject.isSet("proof") && proofObject.get("proof")!.kind === JSONValueKind.OBJECT) {
-            const proofData = proofObject.get("proof")!.toObject()
-            if (proofData.isSet('image')) {
-                proof.proofType = "image"
-                proof.proofData = proofData.get("image")!.toString()
-            }
-            if (proofData.isSet('link')) {
-                proof.proofType = "link"
-                proof.proofData = proofData.get("link")!.toString()
-            }
-            if (proofData.isSet('video')) {
-                proof.proofType = "video"
-                proof.proofData = proofData.get("video")!.toString()
-            }
-            if (proofData.isSet('text')) {
-                proof.proofType = "text"
-                proof.proofData = proofData.get("text")!.toString()
-            }
-        }
-
-        if (proofObject.isSet("description") && proofObject.get("description")!.kind === JSONValueKind.STRING) {
-            proof.description = proofObject.get("description")!.toString()
-        }
-
-        // not part of the official spec, but kept as backwards compatibility
-        if (proofObject.isSet("additional_info") && proofObject.get("additional_info")!.kind === JSONValueKind.STRING) {
-            proof.additionalInfo = proofObject.get("additional_info")!.toString()
-        }
-
-        if (proofObject.isSet("impact") && proofObject.get("impact")!.kind === JSONValueKind.OBJECT) {
-            const impact = proofObject.get("impact")!.toObject()
-
-            if (impact.isSet('carbon') && impact.get('carbon')!.kind === JSONValueKind.NUMBER) { proof.carbon = numberToBigInt(impact.get('carbon')!) }
-            if (impact.isSet('water') && impact.get('water')!.kind === JSONValueKind.NUMBER) { proof.water = numberToBigInt(impact.get('water')!) }
-            if (impact.isSet('energy') && impact.get('energy')!.kind === JSONValueKind.NUMBER) { proof.energy = numberToBigInt(impact.get('energy')!) }
-            if (impact.isSet('waste_mass') && impact.get('waste_mass')!.kind === JSONValueKind.NUMBER) { proof.wasteMass = numberToBigInt(impact.get('waste_mass')!) }
-            if (impact.isSet('plastic') && impact.get('plastic')!.kind === JSONValueKind.NUMBER) { proof.plastic = numberToBigInt(impact.get('plastic')!) }
-            if (impact.isSet('timber') && impact.get('timber')!.kind === JSONValueKind.NUMBER) { proof.timber = numberToBigInt(impact.get('timber')!) }
-            if (impact.isSet('education_time') && impact.get('education_time')!.kind === JSONValueKind.NUMBER) { proof.educationTime = numberToBigInt(impact.get('education_time')!) }
-            if (impact.isSet('trees_planted') && impact.get('trees_planted')!.kind === JSONValueKind.NUMBER) { proof.treesPlanted = numberToBigInt(impact.get('trees_planted')!) }
-            if (impact.isSet('calories_burned') && impact.get('calories_burned')!.kind === JSONValueKind.NUMBER) { proof.caloriesBurned = numberToBigInt(impact.get('calories_burned')!) }
-            if (impact.isSet('sleep_quality_percentage') && impact.get('sleep_quality_percentage')!.kind === JSONValueKind.NUMBER) { proof.sleepQualityPercentage = numberToBigInt(impact.get('sleep_quality_percentage')!) }
-            if (impact.isSet('clean_energy_production') && impact.get('clean_energy_production')!.kind === JSONValueKind.NUMBER) { proof.cleanEnergyProduction = numberToBigInt(impact.get('clean_energy_production')!) }
-        }
-    }
-
-    // default proof is version 1
-    else {
-        proof.version = 1
-
-        if (proofObject.isSet("proof") && proofObject.get("proof")!.kind === JSONValueKind.OBJECT) {
-            const proofData = proofObject.get("proof")!.toObject()
-            if (proofData.isSet('proof_type')) { proof.proofType = proofData.get("proof_type")!.toString() }
-            if (proofData.isSet('proof_data')) { proof.proofData = proofData.get("proof_data")!.toString() }
-        }
-
-        if (proofObject.isSet("metadata") && proofObject.get("metadata")!.kind === JSONValueKind.OBJECT) {
-            const metadata = proofObject.get("metadata")!.toObject()
-            if (metadata.isSet('description')) { proof.description = metadata.get("description")!.toString() }
-            if (metadata.isSet('additional_info')) { proof.additionalInfo = metadata.get("additional_info")!.toString() }
-        }
-
-        if (proofObject.isSet("impact") && proofObject.get("impact")!.kind === JSONValueKind.OBJECT) {
-            const impact = proofObject.get("impact")!.toObject()
-
-            if (impact.isSet('carbon') && impact.get('carbon')!.kind === JSONValueKind.STRING && isDigitsOnly(impact.get('carbon')!.toString())) { proof.carbon = bigInt.fromString(impact.get('carbon')!.toString()) }
-            if (impact.isSet('water') && impact.get('water')!.kind === JSONValueKind.STRING && isDigitsOnly(impact.get('water')!.toString())) { proof.water = bigInt.fromString(impact.get('water')!.toString()) }
-            if (impact.isSet('energy') && impact.get('energy')!.kind === JSONValueKind.STRING && isDigitsOnly(impact.get('energy')!.toString())) { proof.energy = bigInt.fromString(impact.get('energy')!.toString()) }
-            if (impact.isSet('waste_mass') && impact.get('waste_mass')!.kind === JSONValueKind.STRING && isDigitsOnly(impact.get('waste_mass')!.toString())) { proof.wasteMass = bigInt.fromString(impact.get('waste_mass')!.toString()) }
-            if (impact.isSet('waste_items') && impact.get('waste_items')!.kind === JSONValueKind.STRING && isDigitsOnly(impact.get('waste_items')!.toString())) { proof.wasteItems = bigInt.fromString(impact.get('waste_items')!.toString()) }
-            if (impact.isSet('people') && impact.get('people')!.kind === JSONValueKind.STRING && isDigitsOnly(impact.get('people')!.toString())) { proof.people = bigInt.fromString(impact.get('people')!.toString()) }
-            if (impact.isSet('biodiversity') && impact.get('biodiversity')!.kind === JSONValueKind.STRING && isDigitsOnly(impact.get('biodiversity')!.toString())) { proof.biodiversity = bigInt.fromString(impact.get('biodiversity')!.toString()) }
-            if (impact.isSet('plastic') && impact.get('plastic')!.kind === JSONValueKind.STRING && isDigitsOnly(impact.get('plastic')!.toString())) { proof.plastic = bigInt.fromString(impact.get('plastic')!.toString()) }
-            if (impact.isSet('timber') && impact.get('timber')!.kind === JSONValueKind.STRING && isDigitsOnly(impact.get('timber')!.toString())) { proof.timber = bigInt.fromString(impact.get('timber')!.toString()) }
-        }
-    }
-
-    return proof
-}
-
-
-function updateAppSustainability(sustainabilityId: i64, proof: SustainabilityProof): void {
-    const appSustainability = new AppSustainability(sustainabilityId)
-    appSustainability.round = proof.round
-    appSustainability.reward = proof.reward
-    appSustainability.carbon = proof.carbon
-    appSustainability.water = proof.water
-    appSustainability.energy = proof.energy
-    appSustainability.wasteMass = proof.wasteMass
-    appSustainability.plastic = proof.plastic
-    appSustainability.timber = proof.timber
-    appSustainability.timestamp = proof.timestamp
-    appSustainability.app = proof.app
-    appSustainability.account = proof.account
-    appSustainability.educationTime = proof.educationTime
-    appSustainability.treesPlanted = proof.treesPlanted
-    appSustainability.caloriesBurned = proof.caloriesBurned
-    appSustainability.sleepQualityPercentage = proof.sleepQualityPercentage
-    appSustainability.cleanEnergyProduction = proof.cleanEnergyProduction
-
-    // deprecated entries
-    appSustainability.wasteItems = proof.wasteItems
-    appSustainability.people = proof.people
-    appSustainability.biodiversity = proof.biodiversity
-
-
-    const app = App.load(proof.app)!
-    appSustainability.participantsCount = app.participantsCount
-
-    appSustainability.save()
-}
-
-function updateAccountSustainability(proof: SustainabilityProof): boolean[] {
-    const id = [proof.account.toHexString(), proof.app.toHexString()].join('/')
-    let accountSustainability = AccountSustainability.load(id)
+function updateAccountSustainability(account: Bytes, app: App, round: Round, reward: BigInt): boolean[] {
+    const summaryId = accountSustainabilityId(account, app.id)
+    let accountSustainability = AccountSustainability.load(summaryId)
     let isNewParticipant = false
     let isNewRoundParticipant = false
 
     if (accountSustainability == null) {
-        accountSustainability = new AccountSustainability(id)
-
+        accountSustainability = new AccountSustainability(summaryId)
         accountSustainability.receivedRewards = constants.BIGINT_ZERO
-        accountSustainability.carbon = constants.BIGINT_ZERO
-        accountSustainability.water = constants.BIGINT_ZERO
-        accountSustainability.energy = constants.BIGINT_ZERO
-        accountSustainability.wasteMass = constants.BIGINT_ZERO
-        accountSustainability.plastic = constants.BIGINT_ZERO
-        accountSustainability.timber = constants.BIGINT_ZERO
-        accountSustainability.educationTime = constants.BIGINT_ZERO
-        accountSustainability.treesPlanted = constants.BIGINT_ZERO
-        accountSustainability.caloriesBurned = constants.BIGINT_ZERO
-        accountSustainability.sleepQualityPercentage = constants.BIGINT_ZERO
-        accountSustainability.cleanEnergyProduction = constants.BIGINT_ZERO
-        accountSustainability.account = proof.account
-        accountSustainability.app = proof.app
-
-        // deprecated entries
-        accountSustainability.wasteItems = constants.BIGINT_ZERO
-        accountSustainability.people = constants.BIGINT_ZERO
-        accountSustainability.biodiversity = constants.BIGINT_ZERO
-
+        accountSustainability.account = fetchAccount(Address.fromBytes(account)).id
+        accountSustainability.app = app.id
         isNewParticipant = true
     }
 
-    accountSustainability.receivedRewards = accountSustainability.receivedRewards.plus(proof.reward)
-    accountSustainability.carbon = accountSustainability.carbon.plus(proof.carbon)
-    accountSustainability.water = accountSustainability.water.plus(proof.water)
-    accountSustainability.energy = accountSustainability.energy.plus(proof.energy)
-    accountSustainability.wasteMass = accountSustainability.wasteMass.plus(proof.wasteMass)
-    accountSustainability.plastic = accountSustainability.plastic.plus(proof.plastic)
-    accountSustainability.timber = accountSustainability.timber.plus(proof.timber)
-    accountSustainability.educationTime = accountSustainability.educationTime.plus(proof.educationTime)
-    accountSustainability.treesPlanted = accountSustainability.treesPlanted.plus(proof.treesPlanted)
-    accountSustainability.caloriesBurned = accountSustainability.caloriesBurned.plus(proof.caloriesBurned)
-    accountSustainability.sleepQualityPercentage = accountSustainability.sleepQualityPercentage.plus(proof.sleepQualityPercentage)
-    accountSustainability.cleanEnergyProduction = accountSustainability.cleanEnergyProduction.plus(proof.cleanEnergyProduction)
-
-    // deprecated entries
-    accountSustainability.wasteItems = accountSustainability.wasteItems.plus(proof.wasteItems)
-    accountSustainability.people = accountSustainability.people.plus(proof.people)
-    accountSustainability.biodiversity = accountSustainability.biodiversity.plus(proof.biodiversity)
-
+    accountSustainability.receivedRewards = accountSustainability.receivedRewards.plus(reward)
     accountSustainability.save()
 
-    const accountSustainabilityId = [proof.account.toHexString(), proof.app.toHexString(), proof.round].join('/')
-    const knownAccount = AccountRoundSustainability.load(accountSustainabilityId)
-    if (!knownAccount) {
+    if (AccountRoundSustainability.load(accountRoundSustainabilityId(account, app.id, round.id)) == null) {
         isNewRoundParticipant = true
     }
-    const accountRoundSustainability = fetchAccountRoundSustainability(proof.account, fetchApp(proof.app), fetchRound(proof.round))
 
-    accountRoundSustainability.receivedRewards = accountRoundSustainability.receivedRewards.plus(proof.reward)
-    accountRoundSustainability.carbon = accountRoundSustainability.carbon.plus(proof.carbon)
-    accountRoundSustainability.water = accountRoundSustainability.water.plus(proof.water)
-    accountRoundSustainability.energy = accountRoundSustainability.energy.plus(proof.energy)
-    accountRoundSustainability.wasteMass = accountRoundSustainability.wasteMass.plus(proof.wasteMass)
-    accountRoundSustainability.plastic = accountRoundSustainability.plastic.plus(proof.plastic)
-    accountRoundSustainability.timber = accountRoundSustainability.timber.plus(proof.timber)
-    accountRoundSustainability.educationTime = accountRoundSustainability.educationTime.plus(proof.educationTime)
-    accountRoundSustainability.treesPlanted = accountRoundSustainability.treesPlanted.plus(proof.treesPlanted)
-    accountRoundSustainability.caloriesBurned = accountRoundSustainability.caloriesBurned.plus(proof.caloriesBurned)
-    accountRoundSustainability.sleepQualityPercentage = accountRoundSustainability.sleepQualityPercentage.plus(proof.sleepQualityPercentage)
-    accountRoundSustainability.cleanEnergyProduction = accountRoundSustainability.cleanEnergyProduction.plus(proof.cleanEnergyProduction)
-
-    // deprecated entries
-    accountRoundSustainability.wasteItems = accountRoundSustainability.wasteItems.plus(proof.wasteItems)
-    accountRoundSustainability.people = accountRoundSustainability.people.plus(proof.people)
-    accountRoundSustainability.biodiversity = accountRoundSustainability.biodiversity.plus(proof.biodiversity)
-
-    accountRoundSustainability.save()
+    const roundSummary = fetchAccountRoundSustainability(account, app, round)
+    roundSummary.receivedRewards = roundSummary.receivedRewards.plus(reward)
+    roundSummary.save()
 
     return [isNewParticipant, isNewRoundParticipant]
 }
 
-function updateAppRoundSummary(transfer: RewardPoolTransfer): void {
-    const round = Round.load(transfer.round)!
-    const app = App.load(transfer.app)!
-    const appRoundSummary = fetchAppRoundSummary(app, round)
+function updateAppRoundSummary(
+    appRoundSummary: AppRoundSummary,
+    kind: string,
+    amountExact: BigInt,
+    from: Bytes,
+    reason: string | null,
+): void {
+    if (kind == 'DEPOSIT') {
+        appRoundSummary.poolBalanceExact = appRoundSummary.poolBalanceExact.plus(amountExact)
+        appRoundSummary.poolBalance = decimals.toDecimals(appRoundSummary.poolBalanceExact, 18)
 
-    if (transfer.deposit != null) {
-        // Check if this deposit is from the X Allocation Pool - if so, don't count it as a deposit
-        // since allocations are handled separately by the AllocationRewardsClaimed event handler
-        if (transfer.from.equals(Address.fromString("0x4191776f05f4be4848d3f4d587345078b439c7d3"))) {
-            // This is an allocation, not a regular deposit - skip counting it here
-            // Allocations are tracked in handleAllocationRewardsClaimed
-        } else {
-            // This is a regular deposit from a user/app
-            appRoundSummary.poolDepositsExact = appRoundSummary.poolDepositsExact.plus(transfer.amountExact)
+        if (countsAsDeposit(from)) {
+            appRoundSummary.poolDepositsExact = appRoundSummary.poolDepositsExact.plus(amountExact)
             appRoundSummary.poolDeposits = decimals.toDecimals(appRoundSummary.poolDepositsExact, 18)
         }
+
+        appRoundSummary.save()
+        return
     }
 
-    if (transfer.withdraw != null) {
-        appRoundSummary.poolWithdrawalsExact = appRoundSummary.poolWithdrawalsExact.plus(transfer.amountExact)
+    if (kind == 'WITHDRAW') {
+        appRoundSummary.poolBalanceExact = appRoundSummary.poolBalanceExact.minus(amountExact)
+        appRoundSummary.poolBalance = decimals.toDecimals(appRoundSummary.poolBalanceExact, 18)
+        appRoundSummary.poolWithdrawalsExact = appRoundSummary.poolWithdrawalsExact.plus(amountExact)
         appRoundSummary.poolWithdrawals = decimals.toDecimals(appRoundSummary.poolWithdrawalsExact, 18)
+        appRoundSummary.save()
 
-        // group withdrawals by reason for the app/round summary
-        const withdrawal = RewardPoolWithdraw.load(transfer.withdraw!)!
-        const withdrawalReasonId = [appRoundSummary.id, withdrawal.reason.toString()].join('/')
-        let withdrawalReason = AppRoundWithdrawalReason.load(withdrawalReasonId)
-        if (withdrawalReason == null) {
-            withdrawalReason = new AppRoundWithdrawalReason(withdrawalReasonId)
-            withdrawalReason.appRoundSummary = appRoundSummary.id
-            withdrawalReason.reason = withdrawal.reason
-            withdrawalReason.amount = constants.BIGDECIMAL_ZERO
-            withdrawalReason.amountExact = constants.BIGINT_ZERO
+        if (reason != null) {
+            const withdrawalReasonLabel = reason as string
+            const withdrawalReasonId = appRoundSummary.id.toHexString().concat('/').concat(withdrawalReasonLabel)
+            let withdrawalReason = AppRoundWithdrawalReason.load(withdrawalReasonId)
+            if (withdrawalReason == null) {
+                withdrawalReason = new AppRoundWithdrawalReason(withdrawalReasonId)
+                withdrawalReason.appRoundSummary = appRoundSummary.id
+                withdrawalReason.reason = withdrawalReasonLabel
+                withdrawalReason.amount = constants.BIGDECIMAL_ZERO
+                withdrawalReason.amountExact = constants.BIGINT_ZERO
+            }
+
+            withdrawalReason.amountExact = withdrawalReason.amountExact.plus(amountExact)
+            withdrawalReason.amount = decimals.toDecimals(withdrawalReason.amountExact, 18)
+            withdrawalReason.save()
         }
 
-        withdrawalReason.amountExact = withdrawalReason.amountExact.plus(transfer.amountExact)
-        withdrawalReason.amount = decimals.toDecimals(withdrawalReason.amountExact, 18)
-        withdrawalReason.save()
+        return
     }
 
-    if (transfer.distribution != null) {
-        appRoundSummary.poolDistributionsExact = appRoundSummary.poolDistributionsExact.plus(transfer.amountExact)
-        appRoundSummary.poolDistributions = decimals.toDecimals(appRoundSummary.poolDistributionsExact, 18)
-    }
-
+    appRoundSummary.poolBalanceExact = appRoundSummary.poolBalanceExact.minus(amountExact)
+    appRoundSummary.poolBalance = decimals.toDecimals(appRoundSummary.poolBalanceExact, 18)
+    appRoundSummary.poolDistributionsExact = appRoundSummary.poolDistributionsExact.plus(amountExact)
+    appRoundSummary.poolDistributions = decimals.toDecimals(appRoundSummary.poolDistributionsExact, 18)
     appRoundSummary.save()
 }
 
-export function isDigitsOnly(s: string): boolean {
-    for (let i = 0; i < s.length; i++) {
-        let charCode = s.charCodeAt(i);
-        if (charCode < 48 || charCode > 57) { // charCode 48 = '0', 57 = '9'
-            return false;
-        }
-    }
-    return true;
-}
-
-/**
- * Converts a JSONValue NUMBER (which may be a decimal) to BigInt
- * Truncates decimals to maintain compatibility with existing integer values
- * Example: 2.5 becomes 2, 2.9 becomes 2, 10 stays 10
- */
-function numberToBigInt(value: JSONValue): BigInt {
-    // Convert NUMBER to f64 first, then to string
-    const num = value.toF64()
-    const str = num.toString()
-    const parts = str.split('.')
-    
-    return bigInt.fromString(parts[0])
+function countsAsDeposit(from: Bytes): boolean {
+    return !from.equals(X_ALLOCATION_POOL) && !from.equals(DYNAMIC_BASE_ALLOCATIONS)
 }
 
 export function getCurrentRound(): Round {
-    return fetchRound(CurrentRound.load("singleton")!.roundId.toString())
+    return fetchRound(CurrentRound.load('singleton')!.roundId.toString())
 }
 
 export function fetchAppRoundSummary(app: App, round: Round): AppRoundSummary {
-    const id = [app.id.toHexString(), round.id].join('/')
+    const id = appRoundSummaryId(app.id, round.id)
     let appRoundSummary = AppRoundSummary.load(id)
-    if (appRoundSummary) {
+    if (appRoundSummary != null) {
         return appRoundSummary
     }
 
     appRoundSummary = new AppRoundSummary(id)
 
-    const sustainabilityStats = new SustainabilityStats(id)
+    const sustainabilityStats = new SustainabilityStats(sustainabilityStatsId(app.id, round.id))
     sustainabilityStats.participantsCountStart = app.participantsCount
     sustainabilityStats.actionCount = constants.BIGINT_ZERO
     sustainabilityStats.newUserCount = constants.BIGINT_ZERO
     sustainabilityStats.rewards = constants.BIGINT_ZERO
-    sustainabilityStats.carbon = constants.BIGINT_ZERO
-    sustainabilityStats.water = constants.BIGINT_ZERO
-    sustainabilityStats.energy = constants.BIGINT_ZERO
-    sustainabilityStats.wasteMass = constants.BIGINT_ZERO
-    sustainabilityStats.plastic = constants.BIGINT_ZERO
-    sustainabilityStats.timber = constants.BIGINT_ZERO
-    sustainabilityStats.educationTime = constants.BIGINT_ZERO
-    sustainabilityStats.treesPlanted = constants.BIGINT_ZERO
-    sustainabilityStats.caloriesBurned = constants.BIGINT_ZERO
-    sustainabilityStats.sleepQualityPercentage = constants.BIGINT_ZERO
-    sustainabilityStats.cleanEnergyProduction = constants.BIGINT_ZERO
-
-    // deprecated entries
-    sustainabilityStats.wasteItems = constants.BIGINT_ZERO
-    sustainabilityStats.people = constants.BIGINT_ZERO
-    sustainabilityStats.biodiversity = constants.BIGINT_ZERO
-
-    appRoundSummary.sustainabilityStats = sustainabilityStats.id
     sustainabilityStats.save()
 
+    appRoundSummary.sustainabilityStats = sustainabilityStats.id
     appRoundSummary.app = app.id
     appRoundSummary.round = round.id
-
     appRoundSummary.activeUserCount = constants.BIGINT_ZERO
     appRoundSummary.poolAllocations = constants.BIGDECIMAL_ZERO
     appRoundSummary.poolAllocationsExact = constants.BIGINT_ZERO
@@ -659,40 +347,24 @@ export function fetchAppRoundSummary(app: App, round: Round): AppRoundSummary {
     appRoundSummary.poolDistributions = constants.BIGDECIMAL_ZERO
     appRoundSummary.poolDistributionsExact = constants.BIGINT_ZERO
     appRoundSummary.passportScore = constants.BIGINT_ZERO
+    appRoundSummary.save()
 
-    return appRoundSummary;
+    return appRoundSummary
 }
 
 export function fetchAccountRoundSustainability(account: Bytes, app: App, round: Round): AccountRoundSustainability {
-    const id = [account.toHexString(), app.id.toHexString(), round.id].join('/')
+    const id = accountRoundSustainabilityId(account, app.id, round.id)
     let accountRoundSustainability = AccountRoundSustainability.load(id)
-    if (accountRoundSustainability) {
+    if (accountRoundSustainability != null) {
         return accountRoundSustainability
     }
 
     accountRoundSustainability = new AccountRoundSustainability(id)
-
     accountRoundSustainability.passportScore = constants.BIGINT_ZERO
     accountRoundSustainability.receivedRewards = constants.BIGINT_ZERO
-    accountRoundSustainability.carbon = constants.BIGINT_ZERO
-    accountRoundSustainability.water = constants.BIGINT_ZERO
-    accountRoundSustainability.energy = constants.BIGINT_ZERO
-    accountRoundSustainability.wasteMass = constants.BIGINT_ZERO
-    accountRoundSustainability.plastic = constants.BIGINT_ZERO
-    accountRoundSustainability.timber = constants.BIGINT_ZERO
-    accountRoundSustainability.educationTime = constants.BIGINT_ZERO
-    accountRoundSustainability.treesPlanted = constants.BIGINT_ZERO
-    accountRoundSustainability.caloriesBurned = constants.BIGINT_ZERO
-    accountRoundSustainability.sleepQualityPercentage = constants.BIGINT_ZERO
-    accountRoundSustainability.cleanEnergyProduction = constants.BIGINT_ZERO
     accountRoundSustainability.account = fetchAccount(Address.fromBytes(account)).id
     accountRoundSustainability.app = app.id
     accountRoundSustainability.round = round.id
-
-    // deprecated entries
-    accountRoundSustainability.wasteItems = constants.BIGINT_ZERO
-    accountRoundSustainability.people = constants.BIGINT_ZERO
-    accountRoundSustainability.biodiversity = constants.BIGINT_ZERO
 
     return accountRoundSustainability
 }

--- a/src/ThorNode.ts
+++ b/src/ThorNode.ts
@@ -11,7 +11,7 @@ import {
     LevelChanged as LevelChangedEvent,
 } from '../generated/ThorNode/ThorNode'
 import { constants } from '@amxx/graphprotocol-utils'
-import { fetchAccount } from '../node_modules/@openzeppelin/subgraphs/src/fetch/account'
+import { fetchAccount } from './account'
 import { fetchStatsEndorsements } from './XApps';
 import { levelToPoints } from './NodeManagement';
 

--- a/src/Timelock.ts
+++ b/src/Timelock.ts
@@ -1,0 +1,98 @@
+import {
+  TimelockMinDelayChange,
+  TimelockOperationCancelled,
+  TimelockOperationExecuted,
+  TimelockOperationScheduled,
+} from '../generated/schema'
+
+import {
+  CallExecuted as CallExecutedEvent,
+  CallScheduled as CallScheduledEvent,
+  Cancelled as CancelledEvent,
+  MinDelayChange as MinDelayChangeEvent,
+} from '../generated/timelock/Timelock'
+
+import { decimals } from '@amxx/graphprotocol-utils'
+
+import { fetchAccount } from './account'
+import { ensureTransaction, eventEntityId } from './ids'
+import {
+  fetchTimelock,
+  fetchTimelockCall,
+  fetchTimelockOperation,
+} from '../node_modules/@openzeppelin/subgraphs/src/fetch/timelock'
+
+export function handleCallScheduled(event: CallScheduledEvent): void {
+  const contract = fetchTimelock(event.address)
+  const operation = fetchTimelockOperation(contract, event.params.id)
+  const call = fetchTimelockCall(operation, event.params.index)
+  const target = fetchAccount(event.params.target)
+
+  operation.status = 'SCHEDULED'
+  operation.delay = event.params.delay
+  operation.timestamp = event.block.timestamp.plus(event.params.delay)
+  operation.predecessor = event.params.predecessor ? event.params.predecessor.toHex() : null
+  operation.save()
+
+  call.operation = operation.id
+  call.index = event.params.index
+  call.target = target.id
+  call.value = decimals.toDecimals(event.params.value)
+  call.data = event.params.data
+  call.save()
+
+  const scheduled = new TimelockOperationScheduled(eventEntityId(event))
+  scheduled.emitter = contract.id
+  scheduled.transaction = ensureTransaction(event).id
+  scheduled.timestamp = event.block.timestamp
+  scheduled.contract = contract.id
+  scheduled.operation = operation.id
+  scheduled.call = call.id
+  scheduled.save()
+}
+
+export function handleCallExecuted(event: CallExecutedEvent): void {
+  const contract = fetchTimelock(event.address)
+  const operation = fetchTimelockOperation(contract, event.params.id)
+  const call = fetchTimelockCall(operation, event.params.index)
+
+  operation.status = 'EXECUTED'
+  operation.save()
+
+  const executed = new TimelockOperationExecuted(eventEntityId(event))
+  executed.emitter = contract.id
+  executed.transaction = ensureTransaction(event).id
+  executed.timestamp = event.block.timestamp
+  executed.contract = contract.id
+  executed.operation = operation.id
+  executed.call = call.id
+  executed.save()
+}
+
+export function handleCancelled(event: CancelledEvent): void {
+  const contract = fetchTimelock(event.address)
+  const operation = fetchTimelockOperation(contract, event.params.id)
+
+  operation.status = 'CANCELED'
+  operation.save()
+
+  const cancelled = new TimelockOperationCancelled(eventEntityId(event))
+  cancelled.emitter = contract.id
+  cancelled.transaction = ensureTransaction(event).id
+  cancelled.timestamp = event.block.timestamp
+  cancelled.contract = contract.id
+  cancelled.operation = operation.id
+  cancelled.save()
+}
+
+export function handleMinDelayChange(event: MinDelayChangeEvent): void {
+  const contract = fetchTimelock(event.address)
+
+  const minDelayChange = new TimelockMinDelayChange(eventEntityId(event))
+  minDelayChange.emitter = contract.id
+  minDelayChange.transaction = ensureTransaction(event).id
+  minDelayChange.timestamp = event.block.timestamp
+  minDelayChange.contract = contract.id
+  minDelayChange.delay = event.params.newDuration
+  minDelayChange.save()
+}

--- a/src/VeDelegate-ERC721.ts
+++ b/src/VeDelegate-ERC721.ts
@@ -13,21 +13,13 @@ import {
 } from '../generated/erc721/IERC721'
 
 import {
-	events,
-	transactions,
-} from '@amxx/graphprotocol-utils'
-
-import {
-	fetchAccount,
-} from '../node_modules/@openzeppelin/subgraphs/src/fetch/account'
-
-import {
 	fetchERC721,
 	fetchERC721Token,
 	fetchERC721Operator,
 } from '../node_modules/@openzeppelin/subgraphs/src/fetch/erc721'
 import { ERC721Token } from '../generated/schema';
 import { IVeDelegate } from './IVeDelegate';
+import { fetchAccount } from '../node_modules/@openzeppelin/subgraphs/src/fetch/account'
 
 export function handleTransfer(event: TransferEvent): void {
 	let contract = fetchERC721(event.address)

--- a/src/Voting.ts
+++ b/src/Voting.ts
@@ -1,0 +1,52 @@
+import {
+  DelegateChanged,
+} from '../generated/schema'
+
+import {
+  DelegateChanged as DelegateChangedEvent,
+  DelegateVotesChanged as DelegateVotesChangedEvent,
+} from '../generated/voting/Voting'
+
+import {
+  fetchDelegation,
+  fetchVoting,
+  fetchWeight,
+} from '../node_modules/@openzeppelin/subgraphs/src/fetch/voting'
+
+import { ensureTransaction, eventEntityId } from './ids'
+import { fetchAccount } from '../node_modules/@openzeppelin/subgraphs/src/fetch/account'
+
+export function handleDelegateChanged(event: DelegateChangedEvent): void {
+  const delegator = fetchAccount(event.params.delegator)
+  const fromDelegate = fetchAccount(event.params.fromDelegate)
+  const toDelegate = fetchAccount(event.params.toDelegate)
+  const contract = fetchVoting(event.address)
+  const delegation = fetchDelegation(contract, delegator)
+
+  delegation.delegatee = toDelegate.id
+  delegation.save()
+
+  const delegateChanged = new DelegateChanged(eventEntityId(event))
+  delegateChanged.emitter = contract.id
+  delegateChanged.transaction = ensureTransaction(event).id
+  delegateChanged.timestamp = event.block.timestamp
+  delegateChanged.delegation = delegation.id
+  delegateChanged.contract = contract.id
+  delegateChanged.delegator = delegator.id
+  delegateChanged.fromDelegate = fromDelegate.id
+  delegateChanged.toDelegate = toDelegate.id
+  delegateChanged.save()
+}
+
+export function handleDelegateVotesChanged(event: DelegateVotesChangedEvent): void {
+  const delegate = fetchAccount(event.params.delegate)
+  const contract = fetchVoting(event.address)
+  const total = fetchWeight(contract, null)
+  const weight = fetchWeight(contract, delegate)
+
+  total.value = total.value.minus(event.params.previousBalance).plus(event.params.newBalance)
+  weight.value = event.params.newBalance
+
+  total.save()
+  weight.save()
+}

--- a/src/XAllocationVoting.ts
+++ b/src/XAllocationVoting.ts
@@ -2,13 +2,13 @@ import {
     AllocationVoteCast as AllocationVoteCastEvent,
     RoundCreated as RoundCreatedEvent
 } from '../generated/xallocationvoting/XAllocationVoting'
-import { Round, AllocationVote, RoundStatistic, ERC20Balance, AllocationResult, VeDelegateAccount, StatsEndorsement } from '../generated/schema'
-import { decimals, transactions, constants } from '@amxx/graphprotocol-utils'
-import { fetchAccount } from '../node_modules/@openzeppelin/subgraphs/src/fetch/account'
+import { Round, RoundStatistic, ERC20Balance, AllocationResult, VeDelegateAccount, StatsAllocationVote } from '../generated/schema'
+import { decimals, constants } from '@amxx/graphprotocol-utils'
 import { fetchApp } from './XApps'
-import { bigInt, Int8 } from '@graphprotocol/graph-ts'
-import { getUserPassportForRound } from './Passport'
+import { bigInt, BigInt, Bytes } from '@graphprotocol/graph-ts'
 import { CurrentRound } from '../generated/schema'
+import { fetchAccount, incrementAccountAllocationActivity } from './account'
+import { erc20TotalSupplyId } from './ids'
 
 export function handleVoteCast(event: AllocationVoteCastEvent): void {
     const appCount = event.params.appsIds.length
@@ -23,33 +23,14 @@ export function handleVoteCast(event: AllocationVoteCastEvent): void {
         veDelegateStats.voters = veDelegateStats.voters.plus(constants.BIGINT_ONE)
     }
 
-
-    const voterId = fetchAccount(event.params.voter).id
-
-    let passportId = voterId
-    // after VePassport has been deployed
-    if (event.block.number.toI64() >= 19820804) {
-        // get passport at that time
-        passportId = fetchAccount(getUserPassportForRound(event.params.voter, roundId)).id
-    }
-
-
+    const voter = fetchAccount(event.params.voter)
     let totalQFVotesAdjustment = constants.BIGINT_ZERO
     let totalQFVotesAdjustmentVD = constants.BIGINT_ZERO
     for (let index = 0; index < appCount; index += 1) {
         const app = event.params.appsIds[index]
         const appId = app.toHexString()
-        const id = (event.block.number.toI64() * 10000000) + (event.transaction.index.toI64() * 10000) + (event.transactionLogIndex.toI64() * 100) + index
-        const vote = new AllocationVote(id)
         const votesCast = event.params.voteWeights[index]
         const newQFVotes = votesCast.gt(bigInt.fromString("1000000000000000000")) ? votesCast.sqrt() : votesCast.div(bigInt.fromString("1000000000"))
-        vote.voter = voterId
-        vote.passport = passportId
-        vote.round = roundId
-        vote.app = app;
-        vote.weightExact = votesCast
-        vote.weight = decimals.toDecimals(vote.weightExact, 18)
-
 
         // Get the current sum of the square roots of individual votes for the given project
         let allocation = AllocationResult.load([roundId, appId].join('/'))
@@ -78,12 +59,8 @@ export function handleVoteCast(event: AllocationVoteCastEvent): void {
         allocation.votesCast = decimals.toDecimals(allocation.votesCastExact, 18)
         allocation.voters = allocation.voters.plus(constants.BIGINT_ONE)
         allocation.save()
-
-        vote.qfWeightExact = newQFVotes
-        vote.qfWeight = decimals.toDecimals(newQFVotes, 9)
-        vote.timestamp = event.block.timestamp.toI64()
-        vote.transaction = transactions.log(event).id
-        vote.save()
+        updateStatsAllocationVotes(event.block.timestamp.toI64(), roundId, app, allocation)
+        incrementAccountAllocationActivity(voter, votesCast, newQFVotes, event.block.timestamp)
 
         stats.votesCastExact = stats.votesCastExact.plus(votesCast)
         stats.votesCast = decimals.toDecimals(stats.votesCastExact, 18)
@@ -115,6 +92,44 @@ export function handleVoteCast(event: AllocationVoteCastEvent): void {
     }
 
     veDelegateStats.save()
+}
+
+function updateStatsAllocationVotes(timestamp: i64, roundId: string, app: Bytes, allocation: AllocationResult): void {
+    updateStatsAllocationVote(timestamp, roundId, app, allocation, 'HOUR', 3600)
+    updateStatsAllocationVote(timestamp, roundId, app, allocation, 'DAY', 86400)
+}
+
+function updateStatsAllocationVote(
+    timestamp: i64,
+    roundId: string,
+    app: Bytes,
+    allocation: AllocationResult,
+    interval: string,
+    window: i64
+): void {
+    const bucketStart = timestamp - (timestamp % window)
+    const id = [interval, roundId, app.toHexString(), bucketStart.toString()].join('/')
+    let bucket = StatsAllocationVote.load(id)
+
+    if (bucket == null) {
+        bucket = new StatsAllocationVote(id)
+        bucket.interval = interval
+        bucket.timestamp = BigInt.fromI64(bucketStart)
+        bucket.app = app
+        bucket.round = roundId
+        bucket.votes = constants.BIGINT_ZERO
+        bucket.weight = constants.BIGDECIMAL_ZERO
+        bucket.weightExact = constants.BIGINT_ZERO
+        bucket.qfWeight = constants.BIGDECIMAL_ZERO
+        bucket.qfWeightExact = constants.BIGINT_ZERO
+    }
+
+    bucket.votes = bucket.votes.plus(BigInt.fromI32(1))
+    bucket.weight = allocation.votesCast
+    bucket.weightExact = allocation.votesCastExact
+    bucket.qfWeight = allocation.weight
+    bucket.qfWeightExact = allocation.weightExact
+    bucket.save()
 }
 
 export function handleRoundCreated(event: RoundCreatedEvent): void {
@@ -165,13 +180,17 @@ export function handleRoundCreated(event: RoundCreatedEvent): void {
     let stats = fetchStatistic(id, "")
     round.statistic = stats.id
 
-    const totalB3trSupply = ERC20Balance.load(["0x5ef79995fe8a89e0812330e4378eb2660cede699", "totalSupply"].join('/'))
+    const totalB3trSupply = ERC20Balance.load(
+        erc20TotalSupplyId(Bytes.fromHexString('0x5ef79995fe8a89e0812330e4378eb2660cede699') as Bytes)
+    )
     if (totalB3trSupply) {
         stats.b3tr = totalB3trSupply.value
         stats.b3trExact = totalB3trSupply.valueExact
     }
 
-    const totalVot3Supply = ERC20Balance.load(["0x76ca782b59c74d088c7d2cce2f211bc00836c602", "totalSupply"].join('/'))
+    const totalVot3Supply = ERC20Balance.load(
+        erc20TotalSupplyId(Bytes.fromHexString('0x76ca782b59c74d088c7d2cce2f211bc00836c602') as Bytes)
+    )
     if (totalVot3Supply) {
         stats.vot3 = totalVot3Supply.value
         stats.vot3Exact = totalVot3Supply.valueExact

--- a/src/XApps.ts
+++ b/src/XApps.ts
@@ -10,9 +10,11 @@ import {
 import { App, AppEndorsement, NodeDelegation, StatsEndorsement, VeDelegateAccount } from '../generated/schema'
 import { Bytes } from "@graphprotocol/graph-ts";
 import { AppMetadata as AppMetadataTemplate } from '../generated/templates'
-import { constants, transactions } from '@amxx/graphprotocol-utils'
+import { constants } from '@amxx/graphprotocol-utils'
+import { fetchAccount } from './account';
 import { fetchNode } from './ThorNode';
 import { levelToPoints } from './NodeManagement';
+import { ensureTransaction } from './ids';
 
 export function handleAppAdded(event: AppAddedEvent): void {
     const app = fetchApp(event.params.id)
@@ -64,9 +66,9 @@ export function handleAppEndorsed(event: AppEndorsedEvent): void {
     endorsement.app = app.id
 
 
-    endorsement.emitter = event.address
+    endorsement.emitter = fetchAccount(event.address).id
     endorsement.timestamp = event.block.timestamp
-    endorsement.transaction = transactions.log(event).id
+    endorsement.transaction = ensureTransaction(event).id
 
     endorsement.save()
 

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,0 +1,84 @@
+import { Address, BigInt, Entity, Value, ValueKind, store } from '@graphprotocol/graph-ts'
+
+import { Account } from '../generated/schema'
+
+export function fetchAccount(address: Address): Account {
+  let account = Account.load(address)
+
+  if (account == null) {
+    account = new Account(address)
+    account.save()
+  }
+
+  return account
+}
+
+export function incrementAccountAllocationActivity(
+  account: Account,
+  voteWeight: BigInt,
+  qfWeight: BigInt,
+  timestamp: BigInt
+): void {
+  let entity = loadAccountEntity(account)
+  incrementBigIntField(entity, 'allocationVoteCount', BigInt.fromI32(1))
+  incrementBigIntField(entity, 'allocationVotesCastExact', voteWeight)
+  incrementBigIntField(entity, 'allocationQfWeightExact', qfWeight)
+  entity.set('lastActivityTimestamp', Value.fromBigInt(timestamp))
+  store.set('Account', account.id.toHexString(), entity)
+}
+
+export function incrementAccountProposalActivity(
+  account: Account,
+  votesCast: BigInt,
+  weightCast: BigInt,
+  timestamp: BigInt
+): void {
+  let entity = loadAccountEntity(account)
+  incrementBigIntField(entity, 'proposalVoteCount', BigInt.fromI32(1))
+  incrementBigIntField(entity, 'proposalVotesCast', votesCast)
+  incrementBigIntField(entity, 'proposalWeightCast', weightCast)
+  entity.set('lastActivityTimestamp', Value.fromBigInt(timestamp))
+  store.set('Account', account.id.toHexString(), entity)
+}
+
+export function incrementAccountRewardClaims(
+  account: Account,
+  timestamp: BigInt
+): void {
+  let entity = loadAccountEntity(account)
+  incrementBigIntField(entity, 'rewardClaimCount', BigInt.fromI32(1))
+  entity.set('lastActivityTimestamp', Value.fromBigInt(timestamp))
+  store.set('Account', account.id.toHexString(), entity)
+}
+
+export function incrementAccountPassportActivity(
+  account: Account,
+  score: BigInt,
+  timestamp: BigInt
+): void {
+  let entity = loadAccountEntity(account)
+  incrementBigIntField(entity, 'passportActionCount', BigInt.fromI32(1))
+  incrementBigIntField(entity, 'passportScoreTotal', score)
+  entity.set('lastActivityTimestamp', Value.fromBigInt(timestamp))
+  store.set('Account', account.id.toHexString(), entity)
+}
+
+function loadAccountEntity(account: Account): Entity {
+  let entity = store.get('Account', account.id.toHexString())
+  if (entity == null) {
+    entity = new Entity()
+    entity.set('id', Value.fromBytes(account.id))
+  }
+
+  return entity
+}
+
+function incrementBigIntField(entity: Entity, field: string, delta: BigInt): void {
+  let current = entity.get(field)
+  if (current == null || current.kind == ValueKind.NULL) {
+    entity.set(field, Value.fromBigInt(delta))
+    return
+  }
+
+  entity.set(field, Value.fromBigInt(current.toBigInt().plus(delta)))
+}

--- a/src/erc20.ts
+++ b/src/erc20.ts
@@ -1,8 +1,9 @@
-import {
-	Address,
-} from '@graphprotocol/graph-ts'
+import { Address, store } from '@graphprotocol/graph-ts'
 
 import {
+	Account,
+	ERC20Approval,
+	ERC20Balance,
 	VBDBalance,
 	VeDelegateAccount,
 } from '../generated/schema'
@@ -14,50 +15,57 @@ import {
 
 import {
 	decimals,
-	events,
-	transactions,
 } from '@amxx/graphprotocol-utils'
 
-import {
-	fetchAccount,
-} from '../node_modules/@openzeppelin/subgraphs/src/fetch/account'
-
-import {
-	Account as OZAccount,
-} from '../node_modules/@openzeppelin/subgraphs/generated/schema'
-
-import {
-	fetchERC20,
-	fetchERC20Balance,
-	fetchERC20Approval,
-} from '../node_modules/@openzeppelin/subgraphs/src/fetch/erc20'
 import { fetchStatistic } from './XAllocationVoting'
 import { constants } from '@amxx/graphprotocol-utils'
+import { fetchAccount } from './account'
+import { fetchERC20, fetchERC20Approval, fetchERC20Balance, fetchERC20TotalSupply } from './fetch/erc20'
+import { vbdBalanceId, vbdTotalSupplyId } from './ids'
+
+const VOT3_CONTRACT = Address.fromString('0x76Ca782B59C74d088C7D2Cce2f211BC00836c602')
 
 export function handleTransfer(event: TransferEvent): void {
 	let contract = fetchERC20(event.address)
-
-	// Convert B3TR between VOT3
-	if (
-		(event.params.from == Address.zero() && contract.symbol == 'VOT3')
-		||
-		(contract.symbol == 'B3TR' && event.params.from == Address.fromString('0x76Ca782B59C74d088C7D2Cce2f211BC00836c602'))
-	) {
-		const vbdBalance = fetchVBDBalance(fetchAccount(event.params.to))
-		vbdBalance.convertedB3trExact = contract.symbol == 'VOT3'
-			// Convert B3TR to VOT3 (mint VOT3)
-			? vbdBalance.convertedB3trExact.plus(event.params.value)
-			// Convert VOT3 to B3TR (B3TR is sent from VOT3 contract)
-			: vbdBalance.convertedB3trExact.minus(event.params.value)
-
-		vbdBalance.convertedB3tr = decimals.toDecimals(vbdBalance.convertedB3trExact, contract.decimals)
-		vbdBalance.save()
+	let symbol = contract.symbol
+	if (symbol == null) {
+		symbol = ''
 	}
 
-	let isVeDelegateTransferReceiver = false
-	let isVeDelegateTransferSender = false
-	if (event.params.from == Address.zero()) {
-		let totalSupply = fetchERC20Balance(contract, null)
+	let isVot3 = symbol == 'VOT3'
+	let isB3tr = symbol == 'B3TR'
+	let isB3trConversion = false
+	let isMintToVot3 = false
+
+	if (event.params.from.equals(Address.zero())) {
+		if (isVot3) {
+			isMintToVot3 = true
+		}
+	}
+
+	if (isB3tr) {
+		if (event.params.from.equals(VOT3_CONTRACT)) {
+			isB3trConversion = true
+		}
+	}
+
+	// Convert B3TR between VOT3
+	if (isMintToVot3) {
+		const vbdBalance = fetchVBDBalance(fetchAccount(event.params.to))
+		vbdBalance.convertedB3trExact = vbdBalance.convertedB3trExact.plus(event.params.value)
+
+		vbdBalance.convertedB3tr = decimals.toDecimals(vbdBalance.convertedB3trExact, contract.decimals)
+		saveOrRemoveAccountVBDBalance(vbdBalance)
+	} else if (isB3trConversion) {
+		const vbdBalance = fetchVBDBalance(fetchAccount(event.params.to))
+		vbdBalance.convertedB3trExact = vbdBalance.convertedB3trExact.minus(event.params.value)
+
+		vbdBalance.convertedB3tr = decimals.toDecimals(vbdBalance.convertedB3trExact, contract.decimals)
+		saveOrRemoveAccountVBDBalance(vbdBalance)
+	}
+
+	if (event.params.from.equals(Address.zero())) {
+		let totalSupply = fetchERC20TotalSupply(contract)
 		totalSupply.valueExact = totalSupply.valueExact.plus(event.params.value)
 		totalSupply.value = decimals.toDecimals(totalSupply.valueExact, contract.decimals)
 		totalSupply.save()
@@ -66,27 +74,26 @@ export function handleTransfer(event: TransferEvent): void {
 		let balance = fetchERC20Balance(contract, from)
 		balance.valueExact = balance.valueExact.minus(event.params.value)
 		balance.value = decimals.toDecimals(balance.valueExact, contract.decimals)
-		balance.save()
+		saveOrRemoveERC20Balance(balance)
 
 		const vbdBalance = fetchVBDBalance(from)
 		vbdBalance.valueExact = vbdBalance.valueExact.minus(event.params.value)
 		vbdBalance.value = decimals.toDecimals(vbdBalance.valueExact, contract.decimals)
 
-		if (contract.symbol == 'VOT3') {
+		if (isVot3) {
 			vbdBalance.qfWeight = balance.valueExact.sqrt()
 		}
 
-		vbdBalance.save()
+		saveOrRemoveAccountVBDBalance(vbdBalance)
 
 		const veFrom = VeDelegateAccount.load(event.params.from)
 		if (veFrom != null) {
-			isVeDelegateTransferSender = true
 			const tvl = fetchStatistic("tvl", "vedelegate")
-			if (contract.symbol == 'B3TR') {
+			if (isB3tr) {
 				tvl.b3trExact = tvl.b3trExact.minus(event.params.value)
 				tvl.b3tr = decimals.toDecimals(tvl.b3trExact, contract.decimals)
 			}
-			if (contract.symbol == 'VOT3') {
+			if (isVot3) {
 				tvl.vot3Exact = tvl.vot3Exact.minus(event.params.value)
 				tvl.vot3 = decimals.toDecimals(tvl.vot3Exact, contract.decimals)
 			}
@@ -94,43 +101,42 @@ export function handleTransfer(event: TransferEvent): void {
 		}
 	}
 
-	if (event.params.to == Address.zero()) {
-		let totalSupply = fetchERC20Balance(contract, null)
+	if (event.params.to.equals(Address.zero())) {
+		let totalSupply = fetchERC20TotalSupply(contract)
 		totalSupply.valueExact = totalSupply.valueExact.minus(event.params.value)
 		totalSupply.value = decimals.toDecimals(totalSupply.valueExact, contract.decimals)
 		totalSupply.save()
 
 
-		const vbdBalance = fetchVBDBalance(null)
+		const vbdBalance = fetchVBDTotalSupply()
 		vbdBalance.valueExact = vbdBalance.valueExact.minus(event.params.value)
 		vbdBalance.value = decimals.toDecimals(vbdBalance.valueExact, contract.decimals)
-		vbdBalance.save()
+		saveOrRemoveVBDTotalSupply(vbdBalance)
 	} else {
 		let to = fetchAccount(event.params.to)
 		let balance = fetchERC20Balance(contract, to)
 		balance.valueExact = balance.valueExact.plus(event.params.value)
 		balance.value = decimals.toDecimals(balance.valueExact, contract.decimals)
-		balance.save()
+		saveOrRemoveERC20Balance(balance)
 
 
 		const vbdBalance = fetchVBDBalance(to)
 		vbdBalance.valueExact = vbdBalance.valueExact.plus(event.params.value)
 		vbdBalance.value = decimals.toDecimals(vbdBalance.valueExact, contract.decimals)
 
-		if (contract.symbol == 'VOT3') {
+		if (isVot3) {
 			vbdBalance.qfWeight = balance.valueExact.sqrt()
 		}
-		vbdBalance.save()
+		saveOrRemoveAccountVBDBalance(vbdBalance)
 
 		const veTo = VeDelegateAccount.load(event.params.to)
 		if (veTo != null) {
-			isVeDelegateTransferReceiver = true
 			const tvl = fetchStatistic("tvl", "vedelegate")
-			if (contract.symbol == 'B3TR') {
+			if (isB3tr) {
 				tvl.b3trExact = tvl.b3trExact.plus(event.params.value)
 				tvl.b3tr = decimals.toDecimals(tvl.b3trExact, contract.decimals)
 			}
-			if (contract.symbol == 'VOT3') {
+			if (isVot3) {
 				tvl.vot3Exact = tvl.vot3Exact.plus(event.params.value)
 				tvl.vot3 = decimals.toDecimals(tvl.vot3Exact, contract.decimals)
 			}
@@ -147,16 +153,16 @@ export function handleApproval(event: ApprovalEvent): void {
 	let approval = fetchERC20Approval(contract, owner, spender)
 	approval.valueExact = event.params.value
 	approval.value = decimals.toDecimals(event.params.value, contract.decimals)
-	approval.save()
+	saveOrRemoveERC20Approval(approval)
 }
 
-function fetchVBDBalance(account: OZAccount | null): VBDBalance {
-	let id = account ? account.id.toHex() : 'totalSupply'
+function fetchVBDBalance(account: Account): VBDBalance {
+	let id = vbdBalanceId(account.id)
 	let balance = VBDBalance.load(id)
 
 	if (balance == null) {
 		balance = new VBDBalance(id)
-		balance.account = account ? account.id : null
+		balance.account = account.id
 		balance.value = constants.BIGDECIMAL_ZERO
 		balance.valueExact = constants.BIGINT_ZERO
 		balance.convertedB3tr = constants.BIGDECIMAL_ZERO
@@ -166,4 +172,71 @@ function fetchVBDBalance(account: OZAccount | null): VBDBalance {
 	}
 
 	return balance
+}
+
+function fetchVBDTotalSupply(): VBDBalance {
+	let balance = VBDBalance.load(vbdTotalSupplyId())
+
+	if (balance == null) {
+		balance = new VBDBalance(vbdTotalSupplyId())
+		balance.account = null
+		balance.value = constants.BIGDECIMAL_ZERO
+		balance.valueExact = constants.BIGINT_ZERO
+		balance.convertedB3tr = constants.BIGDECIMAL_ZERO
+		balance.convertedB3trExact = constants.BIGINT_ZERO
+		balance.qfWeight = constants.BIGINT_ZERO
+		balance.save()
+	}
+
+	return balance
+}
+
+function saveOrRemoveERC20Balance(balance: ERC20Balance): void {
+	if (balance.valueExact.equals(constants.BIGINT_ZERO)) {
+		store.remove('ERC20Balance', balance.id.toHexString())
+		return
+	}
+
+	balance.save()
+}
+
+function saveOrRemoveERC20Approval(approval: ERC20Approval): void {
+	if (approval.valueExact.equals(constants.BIGINT_ZERO)) {
+		store.remove('ERC20Approval', approval.id.toHexString())
+		return
+	}
+
+	approval.save()
+}
+
+function saveOrRemoveAccountVBDBalance(balance: VBDBalance): void {
+	let hasZeroValue = balance.valueExact.equals(constants.BIGINT_ZERO)
+	let hasZeroConverted = balance.convertedB3trExact.equals(constants.BIGINT_ZERO)
+	let hasZeroWeight = balance.qfWeight.equals(constants.BIGINT_ZERO)
+	if (hasZeroValue) {
+		if (hasZeroConverted) {
+			if (hasZeroWeight) {
+				store.remove('VBDBalance', balance.id.toHexString())
+				return
+			}
+		}
+	}
+
+	balance.save()
+}
+
+function saveOrRemoveVBDTotalSupply(balance: VBDBalance): void {
+	let hasZeroValue = balance.valueExact.equals(constants.BIGINT_ZERO)
+	let hasZeroConverted = balance.convertedB3trExact.equals(constants.BIGINT_ZERO)
+	let hasZeroWeight = balance.qfWeight.equals(constants.BIGINT_ZERO)
+	if (hasZeroValue) {
+		if (hasZeroConverted) {
+			if (hasZeroWeight) {
+				store.remove('VBDBalance', balance.id.toHexString())
+				return
+			}
+		}
+	}
+
+	balance.save()
 }

--- a/src/fetch/erc20.ts
+++ b/src/fetch/erc20.ts
@@ -1,0 +1,86 @@
+import { Address } from '@graphprotocol/graph-ts'
+
+import { Account, ERC20Approval, ERC20Balance, ERC20Contract } from '../../generated/schema'
+import { IERC20 } from '../../generated/erc20/IERC20'
+
+import { constants } from '@amxx/graphprotocol-utils'
+
+import { fetchAccount } from '../account'
+import { erc20ApprovalId, erc20BalanceId, erc20TotalSupplyId } from '../ids'
+
+export function fetchERC20(address: Address): ERC20Contract {
+  let contract = ERC20Contract.load(address)
+
+  if (contract == null) {
+    const endpoint = IERC20.bind(address)
+    const name = endpoint.try_name()
+    const symbol = endpoint.try_symbol()
+    const decimals = endpoint.try_decimals()
+
+    contract = new ERC20Contract(address)
+    contract.name = name.reverted ? null : name.value
+    contract.symbol = symbol.reverted ? null : symbol.value
+    contract.decimals = decimals.reverted ? 18 : decimals.value
+    contract.totalSupply = fetchERC20TotalSupply(contract as ERC20Contract).id
+    contract.asAccount = address
+    contract.save()
+
+    const account = fetchAccount(address)
+    account.asERC20 = address
+    account.save()
+  }
+
+  return contract as ERC20Contract
+}
+
+export function fetchERC20Balance(contract: ERC20Contract, account: Account): ERC20Balance {
+  const id = erc20BalanceId(contract.id, account.id)
+  let balance = ERC20Balance.load(id)
+
+  if (balance == null) {
+    balance = new ERC20Balance(id)
+    balance.contract = contract.id
+    balance.account = account.id
+    balance.value = constants.BIGDECIMAL_ZERO
+    balance.valueExact = constants.BIGINT_ZERO
+    balance.save()
+  }
+
+  return balance as ERC20Balance
+}
+
+export function fetchERC20TotalSupply(contract: ERC20Contract): ERC20Balance {
+  const id = erc20TotalSupplyId(contract.id)
+  let balance = ERC20Balance.load(id)
+
+  if (balance == null) {
+    balance = new ERC20Balance(id)
+    balance.contract = contract.id
+    balance.account = null
+    balance.value = constants.BIGDECIMAL_ZERO
+    balance.valueExact = constants.BIGINT_ZERO
+    balance.save()
+  }
+
+  return balance as ERC20Balance
+}
+
+export function fetchERC20Approval(
+  contract: ERC20Contract,
+  owner: Account,
+  spender: Account,
+): ERC20Approval {
+  const id = erc20ApprovalId(contract.id, owner.id, spender.id)
+  let approval = ERC20Approval.load(id)
+
+  if (approval == null) {
+    approval = new ERC20Approval(id)
+    approval.contract = contract.id
+    approval.owner = owner.id
+    approval.spender = spender.id
+    approval.value = constants.BIGDECIMAL_ZERO
+    approval.valueExact = constants.BIGINT_ZERO
+  }
+
+  return approval as ERC20Approval
+}

--- a/src/fetch/governor.ts
+++ b/src/fetch/governor.ts
@@ -14,7 +14,7 @@ import {
 
 import {
 	fetchAccount
-} from '../../node_modules/@openzeppelin/subgraphs/src/fetch/account'
+} from '../account'
 
 import {
 	constants,

--- a/src/ids.ts
+++ b/src/ids.ts
@@ -1,0 +1,76 @@
+import { ByteArray, Bytes, crypto, ethereum } from '@graphprotocol/graph-ts'
+
+import { Transaction } from '../generated/schema'
+
+export function eventEntityId(event: ethereum.Event): string {
+  return event.block.number.toString().concat('-').concat(event.logIndex.toString())
+}
+
+export function eventBytesId(event: ethereum.Event): Bytes {
+  return event.transaction.hash.concatI32(event.logIndex.toI32())
+}
+
+export function ensureTransaction(event: ethereum.Event): Transaction {
+  const id = event.transaction.hash
+  let transaction = Transaction.load(id)
+
+  if (transaction == null) {
+    transaction = new Transaction(id)
+    transaction.timestamp = event.block.timestamp
+    transaction.blockNumber = event.block.number
+    transaction.save()
+  }
+
+  return transaction
+}
+
+export function appRoundSummaryId(app: Bytes, roundId: string): Bytes {
+  return hashCompositeId('app-round-summary', app.toHexString(), roundId)
+}
+
+export function sustainabilityStatsId(app: Bytes, roundId: string): Bytes {
+  return hashCompositeId('sustainability-stats', app.toHexString(), roundId)
+}
+
+export function accountSustainabilityId(account: Bytes, app: Bytes): Bytes {
+  return hashCompositeId('account-sustainability', account.toHexString(), app.toHexString())
+}
+
+export function accountRoundSustainabilityId(account: Bytes, app: Bytes, roundId: string): Bytes {
+  return hashCompositeId('account-round-sustainability', account.toHexString(), app.toHexString(), roundId)
+}
+
+export function erc20BalanceId(contract: Bytes, account: Bytes): Bytes {
+  return hashCompositeId('erc20-balance', contract.toHexString(), account.toHexString())
+}
+
+export function erc20TotalSupplyId(contract: Bytes): Bytes {
+  return hashCompositeId('erc20-balance', contract.toHexString(), 'totalSupply')
+}
+
+export function erc20ApprovalId(contract: Bytes, owner: Bytes, spender: Bytes): Bytes {
+  return hashCompositeId('erc20-approval', contract.toHexString(), owner.toHexString(), spender.toHexString())
+}
+
+export function vbdBalanceId(account: Bytes): Bytes {
+  return hashCompositeId('vbd-balance', account.toHexString())
+}
+
+export function vbdTotalSupplyId(): Bytes {
+  return hashCompositeId('vbd-balance', 'totalSupply')
+}
+
+export function hashCompositeId(prefix: string, partA: string, partB: string = '', partC: string = ''): Bytes {
+  let key = prefix
+  key = key.concat('/').concat(partA)
+
+  if (partB.length > 0) {
+    key = key.concat('/').concat(partB)
+  }
+
+  if (partC.length > 0) {
+    key = key.concat('/').concat(partC)
+  }
+
+  return Bytes.fromByteArray(crypto.keccak256(ByteArray.fromUTF8(key)))
+}

--- a/subgraph.graphql
+++ b/subgraph.graphql
@@ -1,4 +1,15 @@
 scalar Timestamp
+
+enum StatsInterval {
+  HOUR
+  DAY
+}
+
+enum RewardPoolTransferKind {
+  DEPOSIT
+  WITHDRAW
+  DISTRIBUTION
+}
 """
 Weekly Voting Rounds
 """
@@ -68,14 +79,11 @@ type App @entity(immutable: false) {
   poolBalanceExact: BigInt!
   poolDeposits: BigDecimal!
   poolDepositsExact: BigInt!
-  poolDepositEvent: [RewardPoolDeposit!]! @derivedFrom(field: "app")
   poolWithdrawals: BigDecimal!
   poolWithdrawalsExact: BigInt!
-  poolWithdrawEvent: [RewardPoolWithdraw!]! @derivedFrom(field: "app")
   poolDistributions: BigDecimal!
   poolDistributionsExact: BigInt!
-  poolDistributionEvent: [RewardPoolDistribution!]! @derivedFrom(field: "app")
-  sustainabilityProof: [SustainabilityProof!]! @derivedFrom(field: "app")
+  poolTransfers: [RewardPoolTransfer!]! @derivedFrom(field: "app")
   participants: [AccountSustainability!]! @derivedFrom(field: "app")
   participantsCount: BigInt!
   createdAtBlockNumber: BigInt!
@@ -97,7 +105,7 @@ type AppMetadata @entity(immutable: false) {
 }
 
 type AppRoundSummary @entity(immutable: false) {
-  id: ID!
+  id: Bytes!
   app: App!
   round: Round!
   activeUserCount: BigInt!
@@ -139,40 +147,24 @@ type AllocationResult @entity(immutable: false) {
   votesCastExact: BigInt!
 }
 
-type AllocationVote @entity(immutable: true, timeseries: true) {
-  id: Int8!
-  voter: Account!
-  passport: Account!
-  round: Round!
+type StatsAllocationVote @entity(immutable: false) {
+  id: ID!
+  interval: StatsInterval!
+  timestamp: BigInt!
   app: App!
+  round: Round!
+  votes: BigInt!
   weight: BigDecimal!
   weightExact: BigInt!
   qfWeight: BigDecimal!
   qfWeightExact: BigInt!
-  timestamp: Timestamp!
-  transaction: Transaction!
-}
-
-type StatsAllocationVote
-  @aggregation(intervals: ["hour", "day"], source: "AllocationVote") {
-  id: Int8!
-  timestamp: Timestamp!
-  app: App!
-  round: Round!
-  votes: BigInt! @aggregate(fn: "count", cumulative: false)
-  weight: BigDecimal! @aggregate(fn: "sum", arg: "weight", cumulative: true)
-  weightExact: BigInt!
-    @aggregate(fn: "sum", arg: "weightExact", cumulative: true)
-  qfWeight: BigDecimal! @aggregate(fn: "sum", arg: "qfWeight", cumulative: true)
-  qfWeightExact: BigInt!
-    @aggregate(fn: "sum", arg: "qfWeightExact", cumulative: true)
 }
 
 """
 B3TR Voting Rewards
 """
-type RewardClaimed implements Event @entity(immutable: true) {
-  id: ID!
+type RewardClaimed @entity(immutable: true) {
+  id: Bytes!
   emitter: Account!
   voter: Account!
   round: Round!
@@ -212,8 +204,6 @@ type Account @entity(immutable: false) {
   name: String
   asVeDelegate: [ERC721Token!]! @derivedFrom(field: "poolAddress")
   asERC721: ERC721Contract
-  AllocationVotes: [AllocationVote!]! @derivedFrom(field: "voter")
-  ProposalVotes: [VoteReceipt!]! @derivedFrom(field: "voter")
   B3TRRewards: [RewardClaimed!] @derivedFrom(field: "voter")
   ERC721tokens: [ERC721Token!]! @derivedFrom(field: "owner")
   ERC721operatorOwner: [ERC721Operator!]! @derivedFrom(field: "owner")
@@ -231,13 +221,10 @@ type Account @entity(immutable: false) {
   delegateChangedFromEvent: [DelegateChanged!]!
     @derivedFrom(field: "fromDelegate")
   delegateChangedToEvent: [DelegateChanged!]! @derivedFrom(field: "toDelegate")
-  delegateVotesChangedEvent: [DelegateVotesChanged!]!
-    @derivedFrom(field: "delegate")
   asTimelock: Timelock
   timelockedCalls: [TimelockCall!]! @derivedFrom(field: "target")
   asGovernor: Governor
   proposed: [Proposal!]! @derivedFrom(field: "proposer")
-  voted: [VoteReceipt!]! @derivedFrom(field: "voter")
   proposedCalls: [ProposalCall!]! @derivedFrom(field: "target")
   events: [Event!]! @derivedFrom(field: "emitter")
   sustainability: AccountSustainability @derivedFrom(field: "account")
@@ -250,13 +237,22 @@ type Account @entity(immutable: false) {
   nodeDelegatees: [NodeDelegation!]! @derivedFrom(field: "delegatee")
 
   passportEntities: [PassportEntityLink!]! @derivedFrom(field: "passport")
-  passportScores: [PassportScore!]! @derivedFrom(field: "passport")
 
   userSignals: [UserSignal!]! @derivedFrom(field: "user")
   userSignalsResets: [UserSignalsReset!]! @derivedFrom(field: "user")
   userSignalsResetForApps: [UserSignalsResetForApp!]! @derivedFrom(field: "user")
 
   asThorNode: ThorNode @derivedFrom(field: "owner")
+  allocationVoteCount: BigInt
+  allocationVotesCastExact: BigInt
+  allocationQfWeightExact: BigInt
+  proposalVoteCount: BigInt
+  proposalVotesCast: BigInt
+  proposalWeightCast: BigInt
+  rewardClaimCount: BigInt
+  passportActionCount: BigInt
+  passportScoreTotal: BigInt
+  lastActivityTimestamp: BigInt
 }
 
 """
@@ -305,7 +301,7 @@ type ERC20Contract @entity(immutable: true) {
 }
 
 type VBDBalance @entity(immutable: false) {
-  id: ID!
+  id: Bytes!
   account: Account
   convertedB3tr: BigDecimal!
   convertedB3trExact: BigInt!
@@ -315,7 +311,7 @@ type VBDBalance @entity(immutable: false) {
 }
 
 type ERC20Balance @entity(immutable: false) {
-  id: ID!
+  id: Bytes!
   contract: ERC20Contract!
   account: Account
   value: BigDecimal!
@@ -323,7 +319,7 @@ type ERC20Balance @entity(immutable: false) {
 }
 
 type ERC20Approval @entity(immutable: false) {
-  id: ID!
+  id: Bytes!
   contract: ERC20Contract!
   owner: Account!
   spender: Account!
@@ -341,8 +337,6 @@ type VotingContract @entity(immutable: true) {
   weight: [VoteWeight!]! @derivedFrom(field: "contract")
   delegation: [VoteDelegation!]! @derivedFrom(field: "contract")
   delegateChangedEvent: [DelegateChanged!]! @derivedFrom(field: "contract")
-  delegateVotesChangedEvent: [DelegateVotesChanged!]!
-    @derivedFrom(field: "contract")
 }
 
 type VoteDelegation @entity(immutable: false) {
@@ -358,8 +352,6 @@ type VoteWeight @entity(immutable: false) {
   contract: VotingContract!
   account: Account
   value: BigInt!
-  delegateVotesChangedEvent: [DelegateVotesChanged!]!
-    @derivedFrom(field: "voteWeight")
 }
 
 type DelegateChanged implements Event @entity(immutable: true) {
@@ -372,18 +364,6 @@ type DelegateChanged implements Event @entity(immutable: true) {
   delegator: Account!
   fromDelegate: Account!
   toDelegate: Account!
-}
-
-type DelegateVotesChanged implements Event @entity(immutable: true) {
-  id: ID!
-  emitter: Account!
-  transaction: Transaction!
-  timestamp: BigInt!
-  voteWeight: VoteWeight
-  contract: VotingContract!
-  delegate: Account!
-  oldValue: BigInt!
-  newValue: BigInt!
 }
 
 type Timelock @entity(immutable: true) {
@@ -473,7 +453,6 @@ type Governor @entity(immutable: true) {
   proposalQueued: [ProposalQueued!]! @derivedFrom(field: "governor")
   proposalExecuted: [ProposalExecuted!]! @derivedFrom(field: "governor")
   proposalCanceled: [ProposalCanceled!]! @derivedFrom(field: "governor")
-  votecast: [VoteCast!]! @derivedFrom(field: "governor")
 }
 
 """
@@ -492,12 +471,10 @@ type Proposal @entity(immutable: false) {
   executed: Boolean!
   calls: [ProposalCall!]! @derivedFrom(field: "proposal")
   supports: [ProposalSupport!]! @derivedFrom(field: "proposal")
-  receipts: [VoteReceipt!]! @derivedFrom(field: "proposal")
   proposalCreated: [ProposalCreated!]! @derivedFrom(field: "proposal")
   proposalQueued: [ProposalQueued!]! @derivedFrom(field: "proposal")
   proposalExecuted: [ProposalExecuted!]! @derivedFrom(field: "proposal")
   proposalCanceled: [ProposalCanceled!]! @derivedFrom(field: "proposal")
-  votecast: [VoteCast!]! @derivedFrom(field: "proposal")
   deposits: [ProposalDeposit!] @derivedFrom(field: "proposal")
   depositCount: BigInt!
   depositAmount: BigInt!
@@ -533,43 +510,6 @@ type ProposalSupport @entity(immutable: false) {
   voter: BigInt!
   weight: BigInt!
   power: BigInt!
-  votes: [VoteReceipt!]! @derivedFrom(field: "support")
-}
-
-type VoteReceipt @entity(immutable: true) {
-  id: ID!
-  proposal: Proposal!
-  voter: Account!
-  support: ProposalSupport!
-  weight: BigInt!
-  power: BigInt!
-  reason: String!
-  params: Bytes
-}
-
-type ProposalVote @entity(immutable: true, timeseries: true) {
-  id: Int8!
-  timestamp: Timestamp!
-  proposal: Proposal!
-  voter: Account!
-  support: ProposalSupport!
-  weight: BigInt!
-  power: BigInt!
-  totalWeightCast: BigInt!
-  totalPowerCast: BigInt!
-}
-
-type StatsProposalVote
-  @aggregation(intervals: ["hour", "day"], source: "ProposalVote") {
-  id: Int8!
-  timestamp: Timestamp!
-  proposal: Proposal!
-  support: ProposalSupport!
-  weight: BigInt! @aggregate(fn: "sum", arg: "weight", cumulative: true)
-  power: BigDecimal! @aggregate(fn: "sum", arg: "power", cumulative: true)
-  voters: BigInt! @aggregate(fn: "count", cumulative: true)
-  totalWeightCast: BigInt! @aggregate(fn: "max", arg: "totalWeightCast")
-  totalPowerCast: BigInt! @aggregate(fn: "max", arg: "totalPowerCast")
 }
 
 type ProposalCreated implements Event @entity(immutable: true) {
@@ -610,18 +550,6 @@ type ProposalCanceled implements Event @entity(immutable: true) {
   proposal: Proposal!
 }
 
-type VoteCast implements Event @entity(immutable: true) {
-  id: ID!
-  emitter: Account!
-  transaction: Transaction!
-  timestamp: BigInt!
-  governor: Governor!
-  proposal: Proposal!
-  support: ProposalSupport!
-  receipt: VoteReceipt!
-  voter: Account!
-}
-
 type ProposalDeposit implements Event @entity(immutable: true) {
   id: ID!
   transaction: Transaction!
@@ -643,7 +571,7 @@ interface Event {
 }
 
 type Transaction @entity(immutable: true) {
-  id: ID!
+  id: Bytes!
   timestamp: BigInt!
   blockNumber: BigInt!
   events: [Event!]! @derivedFrom(field: "transaction")
@@ -652,48 +580,8 @@ type Transaction @entity(immutable: true) {
 """
 Rewards Pool Allocation Management
 """
-type RewardPoolDeposit implements Event @entity(immutable: true) {
-  id: ID!
-  transaction: Transaction!
-  emitter: Account!
-  timestamp: BigInt!
-  app: App!
-  round: Round!
-  amount: BigDecimal!
-  amountExact: BigInt!
-  depositor: Account!
-}
-
-type RewardPoolWithdraw implements Event @entity(immutable: true) {
-  id: ID!
-  transaction: Transaction!
-  emitter: Account!
-  timestamp: BigInt!
-  app: App!
-  round: Round!
-  amount: BigDecimal!
-  amountExact: BigInt!
-  by: Account!
-  to: Account!
-  reason: String!
-}
-
-type RewardPoolDistribution implements Event @entity(immutable: true) {
-  id: ID!
-  transaction: Transaction!
-  emitter: Account!
-  timestamp: BigInt!
-  app: App!
-  round: Round!
-  amount: BigDecimal!
-  amountExact: BigInt!
-  by: Account!
-  to: Account!
-  proof: SustainabilityProof
-}
-
-type RewardPoolTransfer implements Event @entity(immutable: true) {
-  id: ID!
+type RewardPoolTransfer @entity(immutable: true) {
+  id: Bytes!
   transaction: Transaction!
   emitter: Account!
   timestamp: BigInt!
@@ -703,265 +591,33 @@ type RewardPoolTransfer implements Event @entity(immutable: true) {
   amountExact: BigInt!
   from: Account!
   to: Account!
-  deposit: RewardPoolDeposit
-  withdraw: RewardPoolWithdraw
-  distribution: RewardPoolDistribution
-}
-
-"""
-Sustainability Proofs
-"""
-type SustainabilityProof @entity(immutable: true) {
-  id: ID!
-  timestamp: Timestamp!
-  app: App!
-  round: Round!
-  account: Account!
-  proofType: String
-  proofData: String
-  description: String
-  additionalInfo: String
-
-  reward: BigInt!
-  transaction: Transaction!
-
-  carbon: BigInt!
-  water: BigInt!
-  energy: BigInt!
-  wasteMass: BigInt!
-  plastic: BigInt!
-  timber: BigInt!
-  educationTime: BigInt!
-  treesPlanted: BigInt!
-  caloriesBurned: BigInt!
-  sleepQualityPercentage: BigInt!
-  cleanEnergyProduction: BigInt!
-
-  """
-  deprecated entries
-  """
-  wasteItems: BigInt!
-  people: BigInt!
-  biodiversity: BigInt!
-
-  version: Int!
+  kind: RewardPoolTransferKind!
+  reason: String
 }
 
 type AccountSustainability @entity(immutable: false) {
-  id: ID!
+  id: Bytes!
   app: App!
   receivedRewards: BigInt!
   account: Account!
-  carbon: BigInt!
-  water: BigInt!
-  energy: BigInt!
-  wasteMass: BigInt!
-  plastic: BigInt!
-  timber: BigInt!
-  educationTime: BigInt!
-  treesPlanted: BigInt!
-  caloriesBurned: BigInt!
-  sleepQualityPercentage: BigInt!
-  cleanEnergyProduction: BigInt!
-
-  """
-  deprecated entries
-  """
-  wasteItems: BigInt!
-  people: BigInt!
-  biodiversity: BigInt!
 }
 
 type AccountRoundSustainability @entity(immutable: false) {
-  id: ID!
+  id: Bytes!
   app: App!
   round: Round!
   receivedRewards: BigInt!
   passportScore: BigInt!
   account: Account!
-  carbon: BigInt!
-  water: BigInt!
-  energy: BigInt!
-  wasteMass: BigInt!
-  plastic: BigInt!
-  timber: BigInt!
-  educationTime: BigInt!
-  treesPlanted: BigInt!
-  caloriesBurned: BigInt!
-  sleepQualityPercentage: BigInt!
-  cleanEnergyProduction: BigInt!
-
-  """
-  deprecated entries
-  """
-  wasteItems: BigInt!
-  people: BigInt!
-  biodiversity: BigInt!
-}
-
-type AppSustainability @entity(immutable: true, timeseries: true) {
-  id: Int8!
-  app: App!
-  round: Round!
-  account: Account!
-  timestamp: Timestamp!
-  reward: BigInt!
-  participantsCount: BigInt!
-
-  carbon: BigInt!
-  water: BigInt!
-  energy: BigInt!
-  wasteMass: BigInt!
-  plastic: BigInt!
-  timber: BigInt!
-  educationTime: BigInt!
-  treesPlanted: BigInt!
-  caloriesBurned: BigInt!
-  sleepQualityPercentage: BigInt!
-  cleanEnergyProduction: BigInt!
-
-  """
-  deprecated entries
-  """
-  wasteItems: BigInt!
-  people: BigInt!
-  biodiversity: BigInt!
-}
-
-type StatsAppSustainability
-  @aggregation(intervals: ["hour", "day"], source: "AppSustainability") {
-  id: Int8!
-  timestamp: Timestamp!
-  app: App!
-
-  actions: BigInt! @aggregate(fn: "count", cumulative: false)
-  rewards: BigInt! @aggregate(fn: "sum", arg: "reward", cumulative: false)
-  carbon: BigInt! @aggregate(fn: "sum", arg: "carbon", cumulative: false)
-  water: BigInt! @aggregate(fn: "sum", arg: "water", cumulative: false)
-  energy: BigInt! @aggregate(fn: "sum", arg: "energy", cumulative: false)
-  wasteMass: BigInt! @aggregate(fn: "sum", arg: "wasteMass", cumulative: false)
-  plastic: BigInt! @aggregate(fn: "sum", arg: "plastic", cumulative: false)
-  timber: BigInt! @aggregate(fn: "sum", arg: "timber", cumulative: false)
-  educationTime: BigInt!
-    @aggregate(fn: "sum", arg: "educationTime", cumulative: false)
-  treesPlanted: BigInt!
-    @aggregate(fn: "sum", arg: "treesPlanted", cumulative: false)
-  caloriesBurned: BigInt! @aggregate(fn: "sum", arg: "caloriesBurned", cumulative: false)
-  sleepQualityPercentage: BigInt! @aggregate(fn: "sum", arg: "sleepQualityPercentage", cumulative: false)
-  cleanEnergyProduction: BigInt! @aggregate(fn: "sum", arg: "cleanEnergyProduction", cumulative: false)
-
-  actionsTotal: BigInt! @aggregate(fn: "count", cumulative: true)
-  carbonTotal: BigInt! @aggregate(fn: "sum", arg: "carbon", cumulative: true)
-  waterTotal: BigInt! @aggregate(fn: "sum", arg: "water", cumulative: true)
-  energyTotal: BigInt! @aggregate(fn: "sum", arg: "energy", cumulative: true)
-  wasteMassTotal: BigInt!
-    @aggregate(fn: "sum", arg: "wasteMass", cumulative: true)
-  plasticTotal: BigInt! @aggregate(fn: "sum", arg: "plastic", cumulative: true)
-  timberTotal: BigInt! @aggregate(fn: "sum", arg: "timber", cumulative: true)
-  educationTimeTotal: BigInt!
-    @aggregate(fn: "sum", arg: "educationTime", cumulative: true)
-  treesPlantedTotal: BigInt!
-    @aggregate(fn: "sum", arg: "treesPlanted", cumulative: true)
-  caloriesBurnedTotal: BigInt! @aggregate(fn: "sum", arg: "caloriesBurned", cumulative: true)
-  sleepQualityPercentageTotal: BigInt! @aggregate(fn: "sum", arg: "sleepQualityPercentage", cumulative: false)
-  cleanEnergyProductionTotal: BigInt! @aggregate(fn: "sum", arg: "cleanEnergyProduction", cumulative: true)
-
-  """
-  deprecated entries
-  """
-  wasteItems: BigInt!
-    @aggregate(fn: "sum", arg: "wasteItems", cumulative: false)
-  people: BigInt! @aggregate(fn: "sum", arg: "people", cumulative: false)
-  biodiversity: BigInt!
-    @aggregate(fn: "sum", arg: "biodiversity", cumulative: false)
-  wasteItemsTotal: BigInt!
-    @aggregate(fn: "sum", arg: "wasteItems", cumulative: true)
-  peopleTotal: BigInt! @aggregate(fn: "sum", arg: "people", cumulative: true)
-  biodiversityTotal: BigInt!
-    @aggregate(fn: "sum", arg: "biodiversity", cumulative: true)
-
-  participantsCount: BigInt! @aggregate(fn: "max", arg: "participantsCount")
-}
-
-type StatsAccountSustainability
-  @aggregation(intervals: ["hour", "day"], source: "AppSustainability") {
-  id: Int8!
-  timestamp: Timestamp!
-  account: Account!
-
-  actions: BigInt! @aggregate(fn: "count", cumulative: false)
-  rewards: BigInt! @aggregate(fn: "sum", arg: "reward", cumulative: false)
-  carbon: BigInt! @aggregate(fn: "sum", arg: "carbon", cumulative: false)
-  water: BigInt! @aggregate(fn: "sum", arg: "water", cumulative: false)
-  energy: BigInt! @aggregate(fn: "sum", arg: "energy", cumulative: false)
-  wasteMass: BigInt! @aggregate(fn: "sum", arg: "wasteMass", cumulative: false)
-  plastic: BigInt! @aggregate(fn: "sum", arg: "plastic", cumulative: false)
-  timber: BigInt! @aggregate(fn: "sum", arg: "timber", cumulative: false)
-  educationTime: BigInt!
-    @aggregate(fn: "sum", arg: "educationTime", cumulative: false)
-  treesPlanted: BigInt!
-    @aggregate(fn: "sum", arg: "treesPlanted", cumulative: false)
-  caloriesBurned: BigInt! @aggregate(fn: "sum", arg: "caloriesBurned", cumulative: false)
-  sleepQualityPercentage: BigInt! @aggregate(fn: "sum", arg: "sleepQualityPercentage", cumulative: false)
-  cleanEnergyProduction: BigInt! @aggregate(fn: "sum", arg: "cleanEnergyProduction", cumulative: false)
-
-  actionsTotal: BigInt! @aggregate(fn: "count", cumulative: true)
-  carbonTotal: BigInt! @aggregate(fn: "sum", arg: "carbon", cumulative: true)
-  waterTotal: BigInt! @aggregate(fn: "sum", arg: "water", cumulative: true)
-  energyTotal: BigInt! @aggregate(fn: "sum", arg: "energy", cumulative: true)
-  wasteMassTotal: BigInt!
-    @aggregate(fn: "sum", arg: "wasteMass", cumulative: true)
-  plasticTotal: BigInt! @aggregate(fn: "sum", arg: "plastic", cumulative: true)
-  timberTotal: BigInt! @aggregate(fn: "sum", arg: "timber", cumulative: true)
-  educationTimeTotal: BigInt!
-    @aggregate(fn: "sum", arg: "educationTime", cumulative: true)
-  treesPlantedTotal: BigInt!
-    @aggregate(fn: "sum", arg: "treesPlanted", cumulative: true)
-  caloriesBurnedTotal: BigInt! @aggregate(fn: "sum", arg: "caloriesBurned", cumulative: true)
-  sleepQualityPercentageTotal: BigInt! @aggregate(fn: "sum", arg: "sleepQualityPercentage", cumulative: false)
-  cleanEnergyProductionTotal: BigInt! @aggregate(fn: "sum", arg: "cleanEnergyProduction", cumulative: true)
-
-  """
-  deprecated entries
-  """
-  wasteItems: BigInt!
-    @aggregate(fn: "sum", arg: "wasteItems", cumulative: false)
-  people: BigInt! @aggregate(fn: "sum", arg: "people", cumulative: false)
-  biodiversity: BigInt!
-    @aggregate(fn: "sum", arg: "biodiversity", cumulative: false)
-  wasteItemsTotal: BigInt!
-    @aggregate(fn: "sum", arg: "wasteItems", cumulative: true)
-  peopleTotal: BigInt! @aggregate(fn: "sum", arg: "people", cumulative: true)
-  biodiversityTotal: BigInt!
-    @aggregate(fn: "sum", arg: "biodiversity", cumulative: true)
 }
 
 type SustainabilityStats @entity(immutable: false) {
-  id: ID!
+  id: Bytes!
   rewards: BigInt!
 
   participantsCountStart: BigInt!
   newUserCount: BigInt!
   actionCount: BigInt!
-
-  carbon: BigInt!
-  water: BigInt!
-  energy: BigInt!
-  wasteMass: BigInt!
-  plastic: BigInt!
-  timber: BigInt!
-  educationTime: BigInt!
-  treesPlanted: BigInt!
-  caloriesBurned: BigInt!
-  sleepQualityPercentage: BigInt!
-  cleanEnergyProduction: BigInt!
-
-  """
-  deprecated entries
-  """
-  wasteItems: BigInt!
-  people: BigInt!
-  biodiversity: BigInt!
 }
 
 """
@@ -1003,20 +659,6 @@ type PassportBlacklist @entity(immutable: false) {
   user: Account!
   blacklistedBy: Account!
   active: Boolean!
-}
-
-type PassportScore implements Event @entity(immutable: true) {
-  id: ID!
-
-  user: Account!
-  passport: Account!
-  round: Round!
-  app: App!
-  score: BigInt!
-
-  transaction: Transaction!
-  emitter: Account!
-  timestamp: BigInt!
 }
 
 """

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -1,8 +1,9 @@
 specVersion: 1.2.0
 features:
-  - grafting
   - ipfsOnEthereumContracts
   - nonDeterministicIpfs
+indexerHints:
+  prune: auto
 schema:
   file: subgraph.graphql
 dataSources:
@@ -119,8 +120,6 @@ dataSources:
       abis:
         - name: XAllocationVoting
           file: ./abis/VeBetterDAO-allocations-voting.json
-        - name: Passport
-          file: ./abis/VeBetterDAO-ve-better-passport.json
       eventHandlers:
         - event: AllocationVoteCast(indexed address,indexed uint256,bytes32[],uint256[])
           handler: handleVoteCast
@@ -200,8 +199,6 @@ dataSources:
       abis:
         - name: RewardsPool
           file: ./abis/VeBetterDAO-x-2-earns-rewards-pool.json
-        - name: XAllocationVoting
-          file: ./abis/VeBetterDAO-allocations-voting.json
       eventHandlers:
         - event: NewDeposit(uint256,indexed bytes32,indexed address)
           handler: handleNewDeposit
@@ -305,7 +302,7 @@ dataSources:
           handler: handleDelegateChanged
         - event: DelegateVotesChanged(indexed address,uint256,uint256)
           handler: handleDelegateVotesChanged
-      file: ./node_modules/@openzeppelin/subgraphs/src/datasources/voting.ts
+      file: ./src/Voting.ts
 
   # Gov: Call Handling
   - kind: ethereum/contract
@@ -333,7 +330,7 @@ dataSources:
           handler: handleCancelled
         - event: MinDelayChange(uint256,uint256)
           handler: handleMinDelayChange
-      file: ./node_modules/@openzeppelin/subgraphs/src/datasources/timelock.ts
+      file: ./src/Timelock.ts
 
   # Gov: Proposals
   - kind: ethereum/contract
@@ -573,16 +570,3 @@ templates:
       abis:
         - name: Governor
           file: ./abis/VeBetterDAO-b3tr-governor.json
-  - kind: file/ipfs
-    name: SustainabilityProof
-    network: mainnet
-    mapping:
-      apiVersion: 0.0.7
-      language: wasm/assemblyscript
-      file: ./src/RewardsPool.ts
-      handler: handleSustainabilityProof
-      entities:
-        - SustainabilityProof
-      abis:
-        - name: RewardsPool
-          file: ./abis/VeBetterDAO-x-2-earns-rewards-pool.json

--- a/tests/erc20.test.ts
+++ b/tests/erc20.test.ts
@@ -1,0 +1,41 @@
+import { assert, beforeEach, clearStore, describe, test } from 'matchstick-as/assembly/index'
+import { Address, BigInt, Bytes } from '@graphprotocol/graph-ts'
+
+import { erc20ApprovalId, erc20BalanceId, erc20TotalSupplyId, vbdBalanceId } from '../src/ids'
+import { handleApproval, handleTransfer } from '../src/erc20'
+import { B3TR_ADDRESS, createERC20ApprovalEvent, createERC20TransferEvent, mockERC20Metadata } from './helpers'
+
+describe('ERC20', () => {
+  beforeEach(() => {
+    clearStore()
+    mockERC20Metadata(B3TR_ADDRESS, 'B3TR', 'B3TR', 18)
+  })
+
+  test('prunes zero balances and zero approvals, then recreates balances on new activity', () => {
+    const alice = Address.fromString('0x0000000000000000000000000000000000000011')
+    const bob = Address.fromString('0x0000000000000000000000000000000000000012')
+    const spender = Address.fromString('0x0000000000000000000000000000000000000013')
+
+    handleTransfer(createERC20TransferEvent(Address.zero(), alice, BigInt.fromI32(100), 1))
+    handleApproval(createERC20ApprovalEvent(alice, spender, BigInt.fromI32(50), 2))
+    handleApproval(createERC20ApprovalEvent(alice, spender, BigInt.zero(), 3))
+    handleTransfer(createERC20TransferEvent(alice, bob, BigInt.fromI32(100), 4))
+    handleTransfer(createERC20TransferEvent(bob, Address.zero(), BigInt.fromI32(100), 5))
+    handleTransfer(createERC20TransferEvent(Address.zero(), alice, BigInt.fromI32(25), 6))
+
+    const aliceBalanceId = erc20BalanceId(B3TR_ADDRESS as Bytes, alice as Bytes).toHexString()
+    const bobBalanceId = erc20BalanceId(B3TR_ADDRESS as Bytes, bob as Bytes).toHexString()
+    const approvalId = erc20ApprovalId(B3TR_ADDRESS as Bytes, alice as Bytes, spender as Bytes).toHexString()
+    const totalSupplyId = erc20TotalSupplyId(B3TR_ADDRESS as Bytes).toHexString()
+    const aliceVbdId = vbdBalanceId(alice as Bytes).toHexString()
+    const bobVbdId = vbdBalanceId(bob as Bytes).toHexString()
+
+    assert.fieldEquals('ERC20Balance', aliceBalanceId, 'valueExact', '25')
+    assert.fieldEquals('ERC20Balance', totalSupplyId, 'valueExact', '25')
+    assert.fieldEquals('VBDBalance', aliceVbdId, 'valueExact', '25')
+
+    assert.notInStore('ERC20Balance', bobBalanceId)
+    assert.notInStore('ERC20Approval', approvalId)
+    assert.notInStore('VBDBalance', bobVbdId)
+  })
+})

--- a/tests/governor.test.ts
+++ b/tests/governor.test.ts
@@ -1,0 +1,73 @@
+import { assert, beforeEach, clearStore, createMockedFunction, describe, test } from 'matchstick-as/assembly/index'
+import { Address, BigInt, Bytes, ethereum } from '@graphprotocol/graph-ts'
+
+import { handleProposalCreated, handleVoteCast } from '../src/Governor'
+import {
+  GOVERNOR_ADDRESS,
+  createGovernorVoteCastEvent,
+  createProposalCreatedEvent,
+} from './helpers'
+
+describe('Governor', () => {
+  beforeEach(() => {
+    clearStore()
+
+    createMockedFunction(
+      GOVERNOR_ADDRESS,
+      'COUNTING_MODE',
+      'COUNTING_MODE():(string)',
+    ).returns([ethereum.Value.fromString('support=bravo&quorum=for,abstain')])
+  })
+
+  test('stores proposal aggregates without receipt or per-vote entities', () => {
+    const proposer = Address.fromString('0x0000000000000000000000000000000000000003')
+    const voter = Address.fromString('0x0000000000000000000000000000000000000004')
+    const proposalId = BigInt.fromI32(7)
+
+    handleProposalCreated(
+      createProposalCreatedEvent(
+        proposalId,
+        proposer,
+        [Address.fromString('0x0000000000000000000000000000000000000005')],
+        [BigInt.zero()],
+        ['execute()'],
+        [Bytes.fromHexString('0x1234') as Bytes],
+        'ipfs://proposal-7',
+        BigInt.fromI32(1),
+        BigInt.fromI32(1000),
+      ),
+    )
+
+    handleVoteCast(
+      createGovernorVoteCastEvent(
+        voter,
+        proposalId,
+        1,
+        BigInt.fromI32(11),
+        BigInt.fromI32(17),
+        'support',
+      ),
+    )
+
+    const storedProposalId = GOVERNOR_ADDRESS.toHex() + '/' + proposalId.toHex()
+    const supportId = storedProposalId + '/1'
+    const legacyVoteId = '210000002'
+
+    assert.fieldEquals('Proposal', storedProposalId, 'voterCount', '1')
+    assert.fieldEquals('Proposal', storedProposalId, 'votesCast', '11')
+    assert.fieldEquals('Proposal', storedProposalId, 'weightCast', '17')
+
+    assert.fieldEquals('ProposalSupport', supportId, 'voter', '1')
+    assert.fieldEquals('ProposalSupport', supportId, 'weight', '11')
+    assert.fieldEquals('ProposalSupport', supportId, 'power', '17')
+
+    assert.fieldEquals('Account', voter.toHexString(), 'proposalVoteCount', '1')
+    assert.fieldEquals('Account', voter.toHexString(), 'proposalVotesCast', '11')
+    assert.fieldEquals('Account', voter.toHexString(), 'proposalWeightCast', '17')
+    assert.fieldEquals('Account', voter.toHexString(), 'lastActivityTimestamp', '7260')
+
+    assert.notInStore('VoteReceipt', legacyVoteId)
+    assert.notInStore('ProposalVote', legacyVoteId)
+    assert.notInStore('VoteCast', '21-2')
+  })
+})

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,298 @@
+import { createMockedFunction, newTypedMockEvent } from 'matchstick-as/assembly/index'
+import { Address, BigInt, Bytes, ethereum } from '@graphprotocol/graph-ts'
+
+import {
+  Approval,
+  Transfer,
+} from '../generated/erc20/IERC20'
+import {
+  AllocationVoteCast,
+  RoundCreated,
+} from '../generated/xallocationvoting/XAllocationVoting'
+import {
+  ProposalCreated,
+  VoteCast,
+} from '../generated/governor/Governor'
+import {
+  NewDeposit,
+  RewardDistributed,
+  TeamWithdrawal,
+} from '../generated/RewardsPool/RewardsPool'
+import { RegisteredAction } from '../generated/passport/Passport'
+import {
+  DelegateChanged,
+  DelegateVotesChanged,
+} from '../generated/voting/Voting'
+
+const DEFAULT_BLOCK_NUMBER = 1
+const DEFAULT_TIMESTAMP = 1
+const DEFAULT_TX_INDEX = 0
+
+export const B3TR_ADDRESS = Address.fromString('0x5ef79995FE8a89e0812330E4378eB2660ceDe699')
+export const XALLOCATION_VOTING_ADDRESS = Address.fromString('0x89A00Bb0947a30FF95BEeF77a66AEdE3842Fe5B7')
+export const GOVERNOR_ADDRESS = Address.fromString('0x00000000000000000000000000000000000000aa')
+export const REWARDS_POOL_ADDRESS = Address.fromString('0x6Bee7DDab6c99d5B2Af0554EaEA484CE18F52631')
+export const PASSPORT_ADDRESS = Address.fromString('0x00000000000000000000000000000000000000bb')
+export const VOTING_ADDRESS = Address.fromString('0x00000000000000000000000000000000000000cc')
+
+export function appId(seed: string): Bytes {
+  return Bytes.fromHexString(seed) as Bytes
+}
+
+export function mockERC20Metadata(
+  address: Address,
+  name: string,
+  symbol: string,
+  decimals: i32,
+): void {
+  createMockedFunction(address, 'name', 'name():(string)').returns([
+    ethereum.Value.fromString(name),
+  ])
+  createMockedFunction(address, 'symbol', 'symbol():(string)').returns([
+    ethereum.Value.fromString(symbol),
+  ])
+  createMockedFunction(address, 'decimals', 'decimals():(uint8)').returns([
+    ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(decimals)),
+  ])
+}
+
+export function createRoundCreatedEvent(
+  roundId: BigInt,
+  proposer: Address,
+  voteStart: BigInt,
+  voteEnd: BigInt,
+  appsIds: Bytes[],
+): RoundCreated {
+  const event = newTypedMockEvent<RoundCreated>()
+  event.parameters = [
+    new ethereum.EventParam('roundId', ethereum.Value.fromUnsignedBigInt(roundId)),
+    new ethereum.EventParam('proposer', ethereum.Value.fromAddress(proposer)),
+    new ethereum.EventParam('voteStart', ethereum.Value.fromUnsignedBigInt(voteStart)),
+    new ethereum.EventParam('voteEnd', ethereum.Value.fromUnsignedBigInt(voteEnd)),
+    new ethereum.EventParam('appsIds', ethereum.Value.fromBytesArray(appsIds)),
+  ]
+  setEventMetadata(event, XALLOCATION_VOTING_ADDRESS, DEFAULT_BLOCK_NUMBER, DEFAULT_TIMESTAMP, 0, DEFAULT_TX_INDEX)
+  return event
+}
+
+export function createAllocationVoteCastEvent(
+  voter: Address,
+  roundId: BigInt,
+  appsIds: Bytes[],
+  voteWeights: BigInt[],
+): AllocationVoteCast {
+  const event = newTypedMockEvent<AllocationVoteCast>()
+  event.parameters = [
+    new ethereum.EventParam('voter', ethereum.Value.fromAddress(voter)),
+    new ethereum.EventParam('roundId', ethereum.Value.fromUnsignedBigInt(roundId)),
+    new ethereum.EventParam('appsIds', ethereum.Value.fromBytesArray(appsIds)),
+    new ethereum.EventParam('voteWeights', ethereum.Value.fromUnsignedBigIntArray(voteWeights)),
+  ]
+  setEventMetadata(event, XALLOCATION_VOTING_ADDRESS, 11, 3610, 1, DEFAULT_TX_INDEX)
+  return event
+}
+
+export function createProposalCreatedEvent(
+  proposalId: BigInt,
+  proposer: Address,
+  targets: Address[],
+  values: BigInt[],
+  signatures: string[],
+  calldatas: Bytes[],
+  description: string,
+  roundIdVoteStart: BigInt,
+  depositThreshold: BigInt,
+): ProposalCreated {
+  const event = newTypedMockEvent<ProposalCreated>()
+  event.parameters = [
+    new ethereum.EventParam('proposalId', ethereum.Value.fromUnsignedBigInt(proposalId)),
+    new ethereum.EventParam('proposer', ethereum.Value.fromAddress(proposer)),
+    new ethereum.EventParam('targets', ethereum.Value.fromAddressArray(targets)),
+    new ethereum.EventParam('values', ethereum.Value.fromUnsignedBigIntArray(values)),
+    new ethereum.EventParam('signatures', ethereum.Value.fromStringArray(signatures)),
+    new ethereum.EventParam('calldatas', ethereum.Value.fromBytesArray(calldatas)),
+    new ethereum.EventParam('description', ethereum.Value.fromString(description)),
+    new ethereum.EventParam('roundIdVoteStart', ethereum.Value.fromUnsignedBigInt(roundIdVoteStart)),
+    new ethereum.EventParam('depositThreshold', ethereum.Value.fromUnsignedBigInt(depositThreshold)),
+  ]
+  setEventMetadata(event, GOVERNOR_ADDRESS, 20, 7200, 1, DEFAULT_TX_INDEX)
+  return event
+}
+
+export function createGovernorVoteCastEvent(
+  voter: Address,
+  proposalId: BigInt,
+  support: i32,
+  weight: BigInt,
+  power: BigInt,
+  reason: string,
+): VoteCast {
+  const event = newTypedMockEvent<VoteCast>()
+  event.parameters = [
+    new ethereum.EventParam('voter', ethereum.Value.fromAddress(voter)),
+    new ethereum.EventParam('proposalId', ethereum.Value.fromUnsignedBigInt(proposalId)),
+    new ethereum.EventParam('support', ethereum.Value.fromI32(support)),
+    new ethereum.EventParam('weight', ethereum.Value.fromUnsignedBigInt(weight)),
+    new ethereum.EventParam('power', ethereum.Value.fromUnsignedBigInt(power)),
+    new ethereum.EventParam('reason', ethereum.Value.fromString(reason)),
+  ]
+  setEventMetadata(event, GOVERNOR_ADDRESS, 21, 7260, 2, 1)
+  return event
+}
+
+export function createRewardDistributedEvent(
+  amount: BigInt,
+  rewardAppId: Bytes,
+  receiver: Address,
+  proof: string,
+  distributor: Address,
+  logIndex: i32 = 3,
+): RewardDistributed {
+  const event = newTypedMockEvent<RewardDistributed>()
+  event.parameters = [
+    new ethereum.EventParam('amount', ethereum.Value.fromUnsignedBigInt(amount)),
+    new ethereum.EventParam('appId', ethereum.Value.fromBytes(rewardAppId)),
+    new ethereum.EventParam('receiver', ethereum.Value.fromAddress(receiver)),
+    new ethereum.EventParam('proof', ethereum.Value.fromString(proof)),
+    new ethereum.EventParam('distributor', ethereum.Value.fromAddress(distributor)),
+  ]
+  setEventMetadata(event, REWARDS_POOL_ADDRESS, 19145969, 86400 + logIndex, logIndex, 0)
+  return event
+}
+
+export function createNewDepositEvent(
+  amount: BigInt,
+  rewardAppId: Bytes,
+  depositor: Address,
+  logIndex: i32 = 1,
+): NewDeposit {
+  const event = newTypedMockEvent<NewDeposit>()
+  event.parameters = [
+    new ethereum.EventParam('amount', ethereum.Value.fromUnsignedBigInt(amount)),
+    new ethereum.EventParam('appId', ethereum.Value.fromBytes(rewardAppId)),
+    new ethereum.EventParam('depositor', ethereum.Value.fromAddress(depositor)),
+  ]
+  setEventMetadata(event, REWARDS_POOL_ADDRESS, 19145969, 86400 + logIndex, logIndex, 0)
+  return event
+}
+
+export function createTeamWithdrawalEvent(
+  amount: BigInt,
+  rewardAppId: Bytes,
+  withdrawer: Address,
+  teamWallet: Address,
+  reason: string,
+  logIndex: i32 = 2,
+): TeamWithdrawal {
+  const event = newTypedMockEvent<TeamWithdrawal>()
+  event.parameters = [
+    new ethereum.EventParam('amount', ethereum.Value.fromUnsignedBigInt(amount)),
+    new ethereum.EventParam('appId', ethereum.Value.fromBytes(rewardAppId)),
+    new ethereum.EventParam('withdrawer', ethereum.Value.fromAddress(withdrawer)),
+    new ethereum.EventParam('teamWallet', ethereum.Value.fromAddress(teamWallet)),
+    new ethereum.EventParam('reason', ethereum.Value.fromString(reason)),
+  ]
+  setEventMetadata(event, REWARDS_POOL_ADDRESS, 19145969, 86400 + logIndex, logIndex, 0)
+  return event
+}
+
+export function createRegisteredActionEvent(
+  user: Address,
+  passport: Address,
+  passportAppId: Bytes,
+  round: BigInt,
+  actionScore: BigInt,
+): RegisteredAction {
+  const event = newTypedMockEvent<RegisteredAction>()
+  event.parameters = [
+    new ethereum.EventParam('user', ethereum.Value.fromAddress(user)),
+    new ethereum.EventParam('passport', ethereum.Value.fromAddress(passport)),
+    new ethereum.EventParam('appId', ethereum.Value.fromBytes(passportAppId)),
+    new ethereum.EventParam('round', ethereum.Value.fromUnsignedBigInt(round)),
+    new ethereum.EventParam('actionScore', ethereum.Value.fromUnsignedBigInt(actionScore)),
+  ]
+  setEventMetadata(event, PASSPORT_ADDRESS, 30, 9000, 4, DEFAULT_TX_INDEX)
+  return event
+}
+
+export function createERC20TransferEvent(
+  from: Address,
+  to: Address,
+  value: BigInt,
+  logIndex: i32,
+  address: Address = B3TR_ADDRESS,
+): Transfer {
+  const event = newTypedMockEvent<Transfer>()
+  event.parameters = [
+    new ethereum.EventParam('from', ethereum.Value.fromAddress(from)),
+    new ethereum.EventParam('to', ethereum.Value.fromAddress(to)),
+    new ethereum.EventParam('value', ethereum.Value.fromUnsignedBigInt(value)),
+  ]
+  setEventMetadata(event, address, 40 + logIndex, 12000 + logIndex, logIndex, 0)
+  return event
+}
+
+export function createERC20ApprovalEvent(
+  owner: Address,
+  spender: Address,
+  value: BigInt,
+  logIndex: i32,
+  address: Address = B3TR_ADDRESS,
+): Approval {
+  const event = newTypedMockEvent<Approval>()
+  event.parameters = [
+    new ethereum.EventParam('owner', ethereum.Value.fromAddress(owner)),
+    new ethereum.EventParam('spender', ethereum.Value.fromAddress(spender)),
+    new ethereum.EventParam('value', ethereum.Value.fromUnsignedBigInt(value)),
+  ]
+  setEventMetadata(event, address, 50 + logIndex, 13000 + logIndex, logIndex, 0)
+  return event
+}
+
+export function createDelegateChangedEvent(
+  delegator: Address,
+  fromDelegate: Address,
+  toDelegate: Address,
+  logIndex: i32 = 1,
+): DelegateChanged {
+  const event = newTypedMockEvent<DelegateChanged>()
+  event.parameters = [
+    new ethereum.EventParam('delegator', ethereum.Value.fromAddress(delegator)),
+    new ethereum.EventParam('fromDelegate', ethereum.Value.fromAddress(fromDelegate)),
+    new ethereum.EventParam('toDelegate', ethereum.Value.fromAddress(toDelegate)),
+  ]
+  setEventMetadata(event, VOTING_ADDRESS, 60 + logIndex, 14000 + logIndex, logIndex, 0)
+  return event
+}
+
+export function createDelegateVotesChangedEvent(
+  delegate: Address,
+  previousBalance: BigInt,
+  newBalance: BigInt,
+  logIndex: i32 = 2,
+): DelegateVotesChanged {
+  const event = newTypedMockEvent<DelegateVotesChanged>()
+  event.parameters = [
+    new ethereum.EventParam('delegate', ethereum.Value.fromAddress(delegate)),
+    new ethereum.EventParam('previousBalance', ethereum.Value.fromUnsignedBigInt(previousBalance)),
+    new ethereum.EventParam('newBalance', ethereum.Value.fromUnsignedBigInt(newBalance)),
+  ]
+  setEventMetadata(event, VOTING_ADDRESS, 60 + logIndex, 14000 + logIndex, logIndex, 0)
+  return event
+}
+
+function setEventMetadata(
+  event: ethereum.Event,
+  address: Address,
+  blockNumber: i32,
+  timestamp: i32,
+  logIndex: i32,
+  txIndex: i32,
+): void {
+  event.address = address
+  event.block.number = BigInt.fromI32(blockNumber)
+  event.block.timestamp = BigInt.fromI32(timestamp)
+  event.logIndex = BigInt.fromI32(logIndex)
+  event.transactionLogIndex = BigInt.fromI32(logIndex)
+  event.transaction.index = BigInt.fromI32(txIndex)
+}

--- a/tests/passport.test.ts
+++ b/tests/passport.test.ts
@@ -1,0 +1,54 @@
+import { assert, beforeEach, clearStore, describe, test } from 'matchstick-as/assembly/index'
+import { Address, BigInt } from '@graphprotocol/graph-ts'
+
+import { handleRegisteredAction } from '../src/Passport'
+import { accountRoundSustainabilityId, appRoundSummaryId } from '../src/ids'
+import { handleRoundCreated } from '../src/XAllocationVoting'
+import {
+  appId,
+  createRegisteredActionEvent,
+  createRoundCreatedEvent,
+} from './helpers'
+
+describe('Passport', () => {
+  beforeEach(() => {
+    clearStore()
+  })
+
+  test('keeps passport score aggregates after removing proof-heavy storage', () => {
+    const proposer = Address.fromString('0x0000000000000000000000000000000000000009')
+    const user = Address.fromString('0x0000000000000000000000000000000000000010')
+    const passport = Address.fromString('0x0000000000000000000000000000000000000011')
+    const scoredAppId = appId('0x0404040404040404040404040404040404040404040404040404040404040404')
+
+    handleRoundCreated(
+      createRoundCreatedEvent(
+        BigInt.fromI32(1),
+        proposer,
+        BigInt.fromI32(100),
+        BigInt.fromI32(200),
+        [scoredAppId],
+      ),
+    )
+
+    handleRegisteredAction(
+      createRegisteredActionEvent(
+        user,
+        passport,
+        scoredAppId,
+        BigInt.fromI32(1),
+        BigInt.fromI32(7),
+      ),
+    )
+
+    const summaryId = appRoundSummaryId(scoredAppId, '1').toHexString()
+    const roundParticipantId = accountRoundSustainabilityId(passport, scoredAppId, '1').toHexString()
+
+    assert.fieldEquals('AppRoundSummary', summaryId, 'passportScore', '7')
+    assert.fieldEquals('AccountRoundSustainability', roundParticipantId, 'passportScore', '7')
+    assert.fieldEquals('RoundStatistic', '1', 'totalActionScores', '7')
+    assert.fieldEquals('Account', passport.toHexString(), 'passportActionCount', '1')
+    assert.fieldEquals('Account', passport.toHexString(), 'passportScoreTotal', '7')
+    assert.fieldEquals('Account', passport.toHexString(), 'lastActivityTimestamp', '9000')
+  })
+})

--- a/tests/rewardspool.test.ts
+++ b/tests/rewardspool.test.ts
@@ -1,0 +1,123 @@
+import { assert, beforeEach, clearStore, describe, test } from 'matchstick-as/assembly/index'
+import { Address, BigDecimal, BigInt, Bytes } from '@graphprotocol/graph-ts'
+
+import { Account, ERC721Contract, ERC721Token, Lock2EarnTerm, VeDelegateAccount } from '../generated/schema'
+import {
+  eventBytesId,
+  accountRoundSustainabilityId,
+  accountSustainabilityId,
+  appRoundSummaryId,
+  sustainabilityStatsId,
+} from '../src/ids'
+import { handleRewardDistribution, handleTeamWithdrawal, handleNewDeposit } from '../src/RewardsPool'
+import { handleRoundCreated } from '../src/XAllocationVoting'
+import {
+  appId,
+  createNewDepositEvent,
+  createRewardDistributedEvent,
+  createRoundCreatedEvent,
+  createTeamWithdrawalEvent,
+} from './helpers'
+
+describe('RewardsPool', () => {
+  beforeEach(() => {
+    clearStore()
+  })
+
+  test('stores one unified reward feed and keeps reward summaries', () => {
+    const proposer = Address.fromString('0x0000000000000000000000000000000000000006')
+    const receiver = Address.fromString('0x0000000000000000000000000000000000000007')
+    const distributor = Address.fromString('0x0000000000000000000000000000000000000008')
+    const depositor = Address.fromString('0x0000000000000000000000000000000000000009')
+    const teamWallet = Address.fromString('0x0000000000000000000000000000000000000010')
+    const rewardAppId = appId('0x0303030303030303030303030303030303030303030303030303030303030303')
+
+    seedLock2Earn(receiver)
+
+    handleRoundCreated(
+      createRoundCreatedEvent(
+        BigInt.fromI32(1),
+        proposer,
+        BigInt.fromI32(100),
+        BigInt.fromI32(200),
+        [rewardAppId],
+      ),
+    )
+
+    const depositEvent = createNewDepositEvent(BigInt.fromI32(100), rewardAppId, depositor, 1)
+    const withdrawalEvent = createTeamWithdrawalEvent(BigInt.fromI32(40), rewardAppId, distributor, teamWallet, 'ops', 2)
+    const distributionEvent = createRewardDistributedEvent(BigInt.fromI32(25), rewardAppId, receiver, 'ipfs://proof-ignored', distributor, 3)
+
+    handleNewDeposit(depositEvent)
+    handleTeamWithdrawal(withdrawalEvent)
+    handleRewardDistribution(distributionEvent)
+
+    const summaryId = appRoundSummaryId(rewardAppId, '1').toHexString()
+    const statsId = sustainabilityStatsId(rewardAppId, '1').toHexString()
+    const accountSummaryId = accountSustainabilityId(receiver, rewardAppId).toHexString()
+    const roundAccountSummaryId = accountRoundSustainabilityId(receiver, rewardAppId, '1').toHexString()
+
+    assert.entityCount('RewardPoolTransfer', 3)
+    assert.fieldEquals('RewardPoolTransfer', eventBytesId(depositEvent).toHexString(), 'kind', 'DEPOSIT')
+    assert.fieldEquals('RewardPoolTransfer', eventBytesId(withdrawalEvent).toHexString(), 'kind', 'WITHDRAW')
+    assert.fieldEquals('RewardPoolTransfer', eventBytesId(withdrawalEvent).toHexString(), 'reason', 'ops')
+    assert.fieldEquals('RewardPoolTransfer', eventBytesId(distributionEvent).toHexString(), 'kind', 'DISTRIBUTION')
+
+    assert.fieldEquals('App', rewardAppId.toHexString(), 'poolBalanceExact', '35')
+    assert.fieldEquals('AppRoundSummary', summaryId, 'activeUserCount', '1')
+    assert.fieldEquals('AppRoundSummary', summaryId, 'poolBalanceExact', '35')
+    assert.fieldEquals('AppRoundSummary', summaryId, 'poolDepositsExact', '100')
+    assert.fieldEquals('AppRoundSummary', summaryId, 'poolWithdrawalsExact', '40')
+    assert.fieldEquals('AppRoundSummary', summaryId, 'poolDistributionsExact', '25')
+    assert.fieldEquals('SustainabilityStats', statsId, 'rewards', '25')
+    assert.fieldEquals('SustainabilityStats', statsId, 'newUserCount', '1')
+    assert.fieldEquals('SustainabilityStats', statsId, 'actionCount', '1')
+    assert.fieldEquals('AccountSustainability', accountSummaryId, 'receivedRewards', '25')
+    assert.fieldEquals('AccountRoundSustainability', roundAccountSummaryId, 'receivedRewards', '25')
+    assert.fieldEquals('Lock2EarnTerm', 'term-1', 'rewardsExact', '25')
+  })
+})
+
+function seedLock2Earn(receiver: Address): void {
+  const nftContract = Address.fromString('0x00000000000000000000000000000000000000f1')
+
+  const contractAccount = new Account(nftContract)
+  contractAccount.save()
+
+  const ownerAccount = new Account(receiver)
+  ownerAccount.save()
+
+  const erc721Contract = new ERC721Contract(nftContract)
+  erc721Contract.asAccount = nftContract
+  erc721Contract.save()
+
+  const token = new ERC721Token('token-1')
+  token.contract = erc721Contract.id
+  token.identifier = BigInt.fromI32(1)
+  token.owner = receiver
+  token.approval = receiver
+  token.save()
+
+  const veAccount = new VeDelegateAccount(receiver)
+  veAccount.account = receiver
+  veAccount.token = token.id
+  veAccount.lock2EarnTermId = 'term-1'
+  veAccount.save()
+
+  const term = new Lock2EarnTerm('term-1')
+  term.tokenId = BigInt.fromI32(1)
+  term.owner = receiver
+  term.startTime = BigInt.zero()
+  term.termLength = BigInt.fromI32(1)
+  term.termInterval = BigInt.fromI32(1)
+  term.endTime = BigInt.fromI32(10)
+  term.closed = false
+  term.createdAt = BigInt.zero()
+  term.updatedAt = BigInt.zero()
+  term.amount = BigDecimal.zero()
+  term.amountExact = BigInt.zero()
+  term.veDelegateAccount = veAccount.id
+  term.rewards = BigDecimal.zero()
+  term.rewardsExact = BigInt.zero()
+  term.save()
+}

--- a/tests/voting.test.ts
+++ b/tests/voting.test.ts
@@ -1,0 +1,28 @@
+import { assert, beforeEach, clearStore, describe, test } from 'matchstick-as/assembly/index'
+import { Address, BigInt } from '@graphprotocol/graph-ts'
+
+import { handleDelegateChanged, handleDelegateVotesChanged } from '../src/Voting'
+import { VOTING_ADDRESS, createDelegateChangedEvent, createDelegateVotesChangedEvent } from './helpers'
+
+describe('Voting', () => {
+  beforeEach(() => {
+    clearStore()
+  })
+
+  test('keeps delegation and vote weight state without raw delegate vote events', () => {
+    const delegator = Address.fromString('0x0000000000000000000000000000000000000021')
+    const oldDelegate = Address.fromString('0x0000000000000000000000000000000000000022')
+    const newDelegate = Address.fromString('0x0000000000000000000000000000000000000023')
+
+    handleDelegateChanged(createDelegateChangedEvent(delegator, oldDelegate, newDelegate, 1))
+    handleDelegateVotesChanged(createDelegateVotesChangedEvent(newDelegate, BigInt.zero(), BigInt.fromI32(12), 2))
+
+    const delegationId = VOTING_ADDRESS.toHexString() + '/' + delegator.toHexString()
+    const totalWeightId = VOTING_ADDRESS.toHexString() + '/total'
+    const delegateWeightId = VOTING_ADDRESS.toHexString() + '/' + newDelegate.toHexString()
+
+    assert.fieldEquals('VoteDelegation', delegationId, 'delegatee', newDelegate.toHexString())
+    assert.fieldEquals('VoteWeight', totalWeightId, 'value', '12')
+    assert.fieldEquals('VoteWeight', delegateWeightId, 'value', '12')
+  })
+})

--- a/tests/xallocationvoting.test.ts
+++ b/tests/xallocationvoting.test.ts
@@ -1,0 +1,69 @@
+import { assert, beforeEach, clearStore, describe, test } from 'matchstick-as/assembly/index'
+import { Address, BigInt } from '@graphprotocol/graph-ts'
+
+import { handleRoundCreated, handleVoteCast } from '../src/XAllocationVoting'
+import { appId, createAllocationVoteCastEvent, createRoundCreatedEvent } from './helpers'
+
+describe('XAllocationVoting', () => {
+  beforeEach(() => {
+    clearStore()
+  })
+
+  test('aggregates allocation votes into round, account, and timeseries buckets without raw vote entities', () => {
+    const voter = Address.fromString('0x0000000000000000000000000000000000000001')
+    const proposer = Address.fromString('0x0000000000000000000000000000000000000002')
+    const primaryApp = appId('0x0101010101010101010101010101010101010101010101010101010101010101')
+    const secondaryApp = appId('0x0202020202020202020202020202020202020202020202020202020202020202')
+
+    handleRoundCreated(
+      createRoundCreatedEvent(
+        BigInt.fromI32(1),
+        proposer,
+        BigInt.fromI32(100),
+        BigInt.fromI32(200),
+        [primaryApp, secondaryApp],
+      ),
+    )
+
+    handleVoteCast(
+      createAllocationVoteCastEvent(
+        voter,
+        BigInt.fromI32(1),
+        [primaryApp, secondaryApp],
+        [
+          BigInt.fromString('4000000000000000000'),
+          BigInt.fromString('1000000000000000000'),
+        ],
+      ),
+    )
+
+    const roundId = '1'
+    const primaryAllocationId = roundId + '/' + primaryApp.toHexString()
+    const hourBucketId = 'HOUR/' + roundId + '/' + primaryApp.toHexString() + '/3600'
+    const dayBucketId = 'DAY/' + roundId + '/' + primaryApp.toHexString() + '/0'
+    const legacyAllocationVoteId = '110000100'
+
+    assert.fieldEquals('RoundStatistic', roundId, 'voters', '1')
+    assert.fieldEquals('RoundStatistic', roundId, 'votesCastExact', '5000000000000000000')
+    assert.fieldEquals('RoundStatistic', roundId, 'weightExact', '5000000000000000000')
+
+    assert.fieldEquals('AllocationResult', primaryAllocationId, 'voters', '1')
+    assert.fieldEquals('AllocationResult', primaryAllocationId, 'votesCastExact', '4000000000000000000')
+    assert.fieldEquals('AllocationResult', primaryAllocationId, 'weightExact', '2000000000')
+
+    assert.entityCount('StatsAllocationVote', 4)
+    assert.fieldEquals('StatsAllocationVote', hourBucketId, 'interval', 'HOUR')
+    assert.fieldEquals('StatsAllocationVote', hourBucketId, 'votes', '1')
+    assert.fieldEquals('StatsAllocationVote', hourBucketId, 'weightExact', '4000000000000000000')
+    assert.fieldEquals('StatsAllocationVote', hourBucketId, 'qfWeightExact', '2000000000')
+    assert.fieldEquals('StatsAllocationVote', dayBucketId, 'interval', 'DAY')
+    assert.fieldEquals('StatsAllocationVote', dayBucketId, 'votes', '1')
+
+    assert.fieldEquals('Account', voter.toHexString(), 'allocationVoteCount', '2')
+    assert.fieldEquals('Account', voter.toHexString(), 'allocationVotesCastExact', '5000000000000000000')
+    assert.fieldEquals('Account', voter.toHexString(), 'allocationQfWeightExact', '3000000000')
+    assert.fieldEquals('Account', voter.toHexString(), 'lastActivityTimestamp', '3610')
+
+    assert.notInStore('AllocationVote', legacyAllocationVoteId)
+  })
+})


### PR DESCRIPTION
## Summary
- collapse reward pool raw history into a single `RewardPoolTransfer` entity with `kind` and optional `reason`
- remove raw `PassportScore` and `DelegateVotesChanged` storage while keeping summary surfaces used by the dashboard
- prune zero-value `ERC20Balance`, `VBDBalance`, and `ERC20Approval` rows and move hot synthetic IDs to `Bytes`
- replace string ID helpers with local byte-ID helpers and document the new low-storage query shape
- add Matchstick coverage for reward feed, zero-row pruning, passport summaries, and voting state

## Validation
- `npm test`

## Storage Result
- namespace total size: `611 GB -> 175 GB`
- table size: `172 GB -> 42 GB`
- index size: `439 GB -> 133 GB`
- zero rows after reindex: `erc20_approval=0`, `erc20_balance=0`, `vbd_balance=0`
